### PR TITLE
[SW-127] Add function to get images by cameras

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -2533,18 +2533,26 @@ class SpotWrapper:
     ) -> typing.Optional[typing.Union[ImageBundle, ImageWithHandBundle]]:
         return self.get_images(self._depth_registered_image_requests)
 
-    def get_images_by_cameras(self, camera_sources):
+    def get_images_by_cameras(
+            self, camera_sources: typing.List[CameraSource]
+    ) -> typing.List[ImageEntry]:
         """Calls the GetImage RPC using the image client with requests
         corresponding to the given cameras.
 
-        Args: Accepts either a list of strings (e.g., ['frontleft', 'hand'])
-                or a list of tuples (e.g. [('frontleft', ['visual', 'depth'], ...]
+        Args:
+           camera_sources: a list of CameraSource objects. There are two
+               possibilities for each item in this list. Either it is
+               CameraSource(camera=Camera.front) or
+               CameraSource(camera=Camera.front, image_types=[ImageType.visual, ImageType.depth_registered)
+
                 - If the former is provided, the image requests will include all
                   image types for each specified camera.
                 - If the latter is provided, the image requests will be
                   limited to the specified image types for each corresponding
-                  camera.  Valid image types are 'visual', 'depth', 'depth_registered'
+                  camera.
+
               Note that duplicates of camera names are not allowed.
+
         Returns:
             a list, where each entry is (camera_name, image_type, image_response)
                 e.g. ('frontleft', 'visual', image_response)

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -119,79 +119,53 @@ ImageWithHandBundle = namedtuple(
     "ImageBundle", ["frontleft", "frontright", "left", "right", "back", "hand"]
 )
 
+IMAGE_SOURCES_BY_CAMERA = {
+    "frontleft": {
+        "visual": "frontleft_fisheye_image",
+        "depth": "frontleft_depth",
+        "depth_registered": "frontleft_depth_in_visual_frame"
+    },
+    "frontright": {
+        "visual": "frontright_fisheye_image",
+        "depth": "frontright_depth",
+        "depth_registered": "frontright_depth_in_visual_frame"
+    },
+    "left": {
+        "visual": "left_fisheye_image",
+        "depth": "left_depth",
+        "depth_registered": "left_depth_in_visual_frame"
+    },
+    "right": {
+        "visual": "right_fisheye_image",
+        "depth": "right_depth",
+        "depth_registered": "right_depth_in_visual_frame"
+    },
+    "back": {
+        "visual": "back_fisheye_image",
+        "depth": "back_depth",
+        "depth_registered": "back_depth_in_visual_frame"
+    },
+    "hand": {
+        "visual": "hand_color_image",
+        "depth": "hand_depth",
+        "depth_registered": "hand_depth_in_color_frame"
+    }
+}
+
 # Added to support getting images for given cameras
 Camera = Enum("Camera", ["frontleft", "frontright", "left", "right", "back", "hand"])
 ImageType = Enum("ImageType", ["visual", "depth", "depth_registered"])
-ImageSource = Enum(
-    "ImageSource",
-    [
-        "frontleft_fisheye_image",
-        "frontleft_depth",
-        "frontleft_depth_in_visual_frame",
-        "frontright_fisheye_image",
-        "frontright_depth",
-        "frontright_depth_in_visual_frame",
-        "left_fisheye_image",
-        "left_depth",
-        "left_depth_in_visual_frame",
-        "right_fisheye_image",
-        "right_depth",
-        "right_depth_in_visual_frame",
-        "back_fisheye_image",
-        "back_depth",
-        "back_depth_in_visual_frame",
-        "hand_color_image",
-        "hand_depth",
-        "hand_depth_in_color_frame",
-    ],
-)
-
 
 @dataclass(frozen=True, eq=True)
 class CameraSource:
     camera: Camera
     image_types: list[ImageType]
 
-
 @dataclass(frozen=True)
 class ImageEntry:
     camera_name: str
     image_type: ImageType
     image_response: image_pb2.ImageResponse
-
-
-IMAGE_SOURCES_BY_CAMERA = {
-    Camera.frontleft: {
-        ImageType.visual: ImageSource.frontleft_fisheye_image,
-        ImageType.depth: ImageSource.frontleft_depth,
-        ImageType.depth_registered: ImageSource.frontleft_depth_in_visual_frame,
-    },
-    Camera.frontright: {
-        ImageType.visual: ImageSource.frontright_fisheye_image,
-        ImageType.depth: ImageSource.frontright_depth,
-        ImageType.depth_registered: ImageSource.frontright_depth_in_visual_frame,
-    },
-    Camera.left: {
-        ImageType.visual: ImageSource.left_fisheye_image,
-        ImageType.depth: ImageSource.left_depth,
-        ImageType.depth_registered: ImageSource.left_depth_in_visual_frame,
-    },
-    Camera.right: {
-        ImageType.visual: ImageSource.right_fisheye_image,
-        ImageType.depth: ImageSource.right_depth,
-        ImageType.depth_registered: ImageSource.right_depth_in_visual_frame,
-    },
-    Camera.back: {
-        ImageType.visual: ImageSource.back_fisheye_image,
-        ImageType.depth: ImageSource.back_depth,
-        ImageType.depth_registered: ImageSource.back_depth_in_visual_frame,
-    },
-    Camera.hand: {
-        ImageType.visual: ImageSource.hand_color_image,
-        ImageType.depth: ImageSource.hand_depth,
-        ImageType.depth_registered: ImageSource.hand_depth_in_color_frame,
-    },
-}
 
 
 def robotToLocalTime(timestamp, robot):

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -145,8 +145,14 @@ ImageSource = Enum('ImageSource',
 @dataclass(frozen=True, eq=True)
 class CameraSource:
     camera: Camera
+    image_types: list[ImageType]
+
+@dataclass(frozen=True)
+class ImageEntry:
+    camera_name: str
     image_type: ImageType
     image_response: image_pb2.ImageResponse
+
 
 IMAGE_SOURCES_BY_CAMERA = {
     Camera.frontleft: {
@@ -180,7 +186,6 @@ IMAGE_SOURCES_BY_CAMERA = {
         ImageType.depth_registered: ImageSource.hand_depth_in_color_frame
     },
 }
-ImageEntry = namedtuple("ImageEntry", ["camera_name", "image_type", "image_response"])
 
 
 def robotToLocalTime(timestamp, robot):

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -120,32 +120,38 @@ ImageWithHandBundle = namedtuple(
 )
 
 # Added to support getting images for given cameras
-Camera = Enum('Camera', ['frontleft', 'frontright', 'left', 'right', 'back', 'hand'])
-ImageType = Enum('ImageType', ["visual", "depth", "depth_registered"])
-ImageSource = Enum('ImageSource',
-                   ['frontleft_fisheye_image',
-                    'frontleft_depth',
-                    'frontleft_depth_in_visual_frame',
-                    'frontright_fisheye_image',
-                    'frontright_depth',
-                    'frontright_depth_in_visual_frame',
-                    'left_fisheye_image',
-                    'left_depth',
-                    'left_depth_in_visual_frame',
-                    'right_fisheye_image',
-                    'right_depth',
-                    'right_depth_in_visual_frame',
-                    'back_fisheye_image',
-                    'back_depth',
-                    'back_depth_in_visual_frame',
-                    "hand_color_image",
-                    "hand_depth",
-                    "hand_depth_in_color_frame"])
+Camera = Enum("Camera", ["frontleft", "frontright", "left", "right", "back", "hand"])
+ImageType = Enum("ImageType", ["visual", "depth", "depth_registered"])
+ImageSource = Enum(
+    "ImageSource",
+    [
+        "frontleft_fisheye_image",
+        "frontleft_depth",
+        "frontleft_depth_in_visual_frame",
+        "frontright_fisheye_image",
+        "frontright_depth",
+        "frontright_depth_in_visual_frame",
+        "left_fisheye_image",
+        "left_depth",
+        "left_depth_in_visual_frame",
+        "right_fisheye_image",
+        "right_depth",
+        "right_depth_in_visual_frame",
+        "back_fisheye_image",
+        "back_depth",
+        "back_depth_in_visual_frame",
+        "hand_color_image",
+        "hand_depth",
+        "hand_depth_in_color_frame",
+    ],
+)
+
 
 @dataclass(frozen=True, eq=True)
 class CameraSource:
     camera: Camera
     image_types: list[ImageType]
+
 
 @dataclass(frozen=True)
 class ImageEntry:
@@ -183,7 +189,7 @@ IMAGE_SOURCES_BY_CAMERA = {
     Camera.hand: {
         ImageType.visual: ImageSource.hand_color_image,
         ImageType.depth: ImageSource.hand_depth,
-        ImageType.depth_registered: ImageSource.hand_depth_in_color_frame
+        ImageType.depth_registered: ImageSource.hand_depth_in_color_frame,
     },
 }
 
@@ -2564,9 +2570,7 @@ class SpotWrapper:
         cameras_specified = set()
         for item in camera_sources:
             if item.camera in cameras_specified:
-                self._logger.error(
-                    f"Duplicated camera source for camera {item.camera}"
-                )
+                self._logger.error(f"Duplicated camera source for camera {item.camera}")
                 return None
             image_types = item.image_types
             if image_types is None:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -2585,7 +2585,7 @@ class SpotWrapper:
         # Send image requests
         try:
             image_responses = self._image_client.get_image(image_requests)
-        except UnsupportedPixelFormatRequestedError as e:
+        except UnsupportedPixelFormatRequestedError:
             self._logger.error(
                 "UnsupportedPixelFormatRequestedError. "
                 "Likely pixel_format is set wrong for some image request"

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -4,7 +4,9 @@ import math
 import time
 import traceback
 import typing
+from enum import Enum
 from collections import namedtuple
+from dataclasses import dataclass, field
 
 import bosdyn.client.auth
 from bosdyn.api import arm_command_pb2
@@ -118,39 +120,66 @@ ImageWithHandBundle = namedtuple(
 )
 
 # Added to support getting images for given cameras
+Camera = Enum('Camera', ['frontleft', 'frontright', 'left', 'right', 'back', 'hand'])
+ImageType = Enum('ImageType', ["visual", "depth", "depth_registered"])
+ImageSource = Enum('ImageSource',
+                   ['frontleft_fisheye_image',
+                    'frontleft_depth',
+                    'frontleft_depth_in_visual_frame',
+                    'frontright_fisheye_image',
+                    'frontright_depth',
+                    'frontright_depth_in_visual_frame',
+                    'left_fisheye_image',
+                    'left_depth',
+                    'left_depth_in_visual_frame',
+                    'right_fisheye_image',
+                    'right_depth',
+                    'right_depth_in_visual_frame',
+                    'back_fisheye_image',
+                    'back_depth',
+                    'back_depth_in_visual_frame',
+                    "hand_color_image",
+                    "hand_depth",
+                    "hand_depth_in_color_frame"])
+
+@dataclass(frozen=True, eq=True)
+class CameraSource:
+    camera: Camera
+    image_type: ImageType
+    image_response: image_pb2.ImageResponse
+
 IMAGE_SOURCES_BY_CAMERA = {
-    "frontleft": {
-        "visual": "frontleft_fisheye_image",
-        "depth": "frontleft_depth",
-        "depth_registered": "frontleft_depth_in_visual_frame",
+    Camera.frontleft: {
+        ImageType.visual: ImageSource.frontleft_fisheye_image,
+        ImageType.depth: ImageSource.frontleft_depth,
+        ImageType.depth_registered: ImageSource.frontleft_depth_in_visual_frame,
     },
-    "frontright": {
-        "visual": "frontright_fisheye_image",
-        "depth": "frontright_depth",
-        "depth_registered": "frontright_depth_in_visual_frame",
+    Camera.frontright: {
+        ImageType.visual: ImageSource.frontright_fisheye_image,
+        ImageType.depth: ImageSource.frontright_depth,
+        ImageType.depth_registered: ImageSource.frontright_depth_in_visual_frame,
     },
-    "left": {
-        "visual": "left_fisheye_image",
-        "depth": "left_depth",
-        "depth_registered": "left_depth_in_visual_frame",
+    Camera.left: {
+        ImageType.visual: ImageSource.left_fisheye_image,
+        ImageType.depth: ImageSource.left_depth,
+        ImageType.depth_registered: ImageSource.left_depth_in_visual_frame,
     },
-    "right": {
-        "visual": "right_fisheye_image",
-        "depth": "right_depth",
-        "depth_registered": "right_depth_in_visual_frame",
+    Camera.right: {
+        ImageType.visual: ImageSource.right_fisheye_image,
+        ImageType.depth: ImageSource.right_depth,
+        ImageType.depth_registered: ImageSource.right_depth_in_visual_frame,
     },
-    "back": {
-        "visual": "back_fisheye_image",
-        "depth": "back_depth",
-        "depth_registered": "back_depth_in_visual_frame",
+    Camera.back: {
+        ImageType.visual: ImageSource.back_fisheye_image,
+        ImageType.depth: ImageSource.back_depth,
+        ImageType.depth_registered: ImageSource.back_depth_in_visual_frame,
     },
-    "hand": {
-        "visual": "hand_color_image",
-        "depth": "hand_depth",
-        "depth_registered": "hand_depth_in_color_frame",
+    Camera.hand: {
+        ImageType.visual: ImageSource.hand_color_image,
+        ImageType.depth: ImageSource.hand_depth,
+        ImageType.depth_registered: ImageSource.hand_depth_in_color_frame
     },
 }
-IMAGE_TYPES = {"visual", "depth", "depth_registered"}
 ImageEntry = namedtuple("ImageEntry", ["camera_name", "image_type", "image_response"])
 
 

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -784,14 +784,17 @@ class SpotWrapper:
                 for image_type in image_types:
                     if image_type.startswith("depth"):
                         image_format = image_pb2.Image.FORMAT_RAW
+                        pixel_format = image_pb2.Image.PIXEL_FORMAT_DEPTH_U16
                     else:
                         image_format = image_pb2.Image.FORMAT_JPEG
+                        pixel_format = image_pb2.Image.PIXEL_FORMAT_RGB_U8
 
                     source = IMAGE_SOURCES_BY_CAMERA[camera][image_type]
                     self._image_requests_by_camera[camera][image_type] = \
                         build_image_request(
                             source,
                             image_format=image_format,
+                            pixel_format=pixel_format,
                             quality_percent=75)
 
             # Store the most recent knowledge of the state of the robot based on rpc calls.

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -123,41 +123,43 @@ IMAGE_SOURCES_BY_CAMERA = {
     "frontleft": {
         "visual": "frontleft_fisheye_image",
         "depth": "frontleft_depth",
-        "depth_registered": "frontleft_depth_in_visual_frame"
+        "depth_registered": "frontleft_depth_in_visual_frame",
     },
     "frontright": {
         "visual": "frontright_fisheye_image",
         "depth": "frontright_depth",
-        "depth_registered": "frontright_depth_in_visual_frame"
+        "depth_registered": "frontright_depth_in_visual_frame",
     },
     "left": {
         "visual": "left_fisheye_image",
         "depth": "left_depth",
-        "depth_registered": "left_depth_in_visual_frame"
+        "depth_registered": "left_depth_in_visual_frame",
     },
     "right": {
         "visual": "right_fisheye_image",
         "depth": "right_depth",
-        "depth_registered": "right_depth_in_visual_frame"
+        "depth_registered": "right_depth_in_visual_frame",
     },
     "back": {
         "visual": "back_fisheye_image",
         "depth": "back_depth",
-        "depth_registered": "back_depth_in_visual_frame"
+        "depth_registered": "back_depth_in_visual_frame",
     },
     "hand": {
         "visual": "hand_color_image",
         "depth": "hand_depth",
-        "depth_registered": "hand_depth_in_color_frame"
-    }
+        "depth_registered": "hand_depth_in_color_frame",
+    },
 }
 
 IMAGE_TYPES = {"visual", "depth", "depth_registered"}
+
 
 @dataclass(frozen=True, eq=True)
 class CameraSource:
     camera_name: str
     image_types: list[str]
+
 
 @dataclass(frozen=True)
 class ImageEntry:
@@ -2541,7 +2543,9 @@ class SpotWrapper:
         cameras_specified = set()
         for item in camera_sources:
             if item.camera_name in cameras_specified:
-                self._logger.error(f"Duplicated camera source for camera {item.camera_name}")
+                self._logger.error(
+                    f"Duplicated camera source for camera {item.camera_name}"
+                )
                 return None
             image_types = item.image_types
             if image_types is None:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -122,38 +122,36 @@ IMAGE_SOURCES_BY_CAMERA = {
     "frontleft": {
         "visual": "frontleft_fisheye_image",
         "depth": "frontleft_depth",
-        "depth_registered": "frontleft_depth_in_visual_frame"
+        "depth_registered": "frontleft_depth_in_visual_frame",
     },
     "frontright": {
         "visual": "frontright_fisheye_image",
         "depth": "frontright_depth",
-        "depth_registered": "frontright_depth_in_visual_frame"
+        "depth_registered": "frontright_depth_in_visual_frame",
     },
     "left": {
         "visual": "left_fisheye_image",
         "depth": "left_depth",
-        "depth_registered": "left_depth_in_visual_frame"
+        "depth_registered": "left_depth_in_visual_frame",
     },
     "right": {
         "visual": "right_fisheye_image",
         "depth": "right_depth",
-        "depth_registered": "right_depth_in_visual_frame"
+        "depth_registered": "right_depth_in_visual_frame",
     },
     "back": {
         "visual": "back_fisheye_image",
         "depth": "back_depth",
-        "depth_registered": "back_depth_in_visual_frame"
+        "depth_registered": "back_depth_in_visual_frame",
     },
     "hand": {
         "visual": "hand_color_image",
         "depth": "hand_depth",
-        "depth_registered": "hand_depth_in_color_frame"
-    }
+        "depth_registered": "hand_depth_in_color_frame",
+    },
 }
 IMAGE_TYPES = {"visual", "depth", "depth_registered"}
-ImageEntry = namedtuple(
-    "ImageEntry", ["camera_name", "image_type", "image_response"]
-)
+ImageEntry = namedtuple("ImageEntry", ["camera_name", "image_type", "image_response"])
 
 
 def robotToLocalTime(timestamp, robot):
@@ -790,12 +788,14 @@ class SpotWrapper:
                         pixel_format = image_pb2.Image.PIXEL_FORMAT_RGB_U8
 
                     source = IMAGE_SOURCES_BY_CAMERA[camera][image_type]
-                    self._image_requests_by_camera[camera][image_type] = \
-                        build_image_request(
-                            source,
-                            image_format=image_format,
-                            pixel_format=pixel_format,
-                            quality_percent=75)
+                    self._image_requests_by_camera[camera][
+                        image_type
+                    ] = build_image_request(
+                        source,
+                        image_format=image_format,
+                        pixel_format=pixel_format,
+                        quality_percent=75,
+                    )
 
             # Store the most recent knowledge of the state of the robot based on rpc calls.
             self._current_graph = None
@@ -2526,30 +2526,42 @@ class SpotWrapper:
                 camera_name = item[0]
                 image_types = item[1]
                 if not all(t in IMAGE_TYPES for t in image_types):
-                    self._logger.error(f"Invalid image type in {image_types}. Must be among {IMAGE_TYPES}")
+                    self._logger.error(
+                        f"Invalid image type in {image_types}. Must be among {IMAGE_TYPES}"
+                    )
                     return None
             else:
-                self._logger.error(f"Invalid item in camera_sources: {item}. "
-                                   "Either a string, e.g. 'frontleft', or a tuple "
-                                   "e.g. ('frontleft', ['visual', 'depth'])")
+                self._logger.error(
+                    f"Invalid item in camera_sources: {item}. "
+                    "Either a string, e.g. 'frontleft', or a tuple "
+                    "e.g. ('frontleft', ['visual', 'depth'])"
+                )
                 return None
 
             for image_type in image_types:
-                image_requests.append(self._image_requests_by_camera[camera_name][image_type])
+                image_requests.append(
+                    self._image_requests_by_camera[camera_name][image_type]
+                )
                 source_types.append((camera_name, image_type))
 
         # Send image requests
         try:
             image_responses = self._image_client.get_image(image_requests)
         except UnsupportedPixelFormatRequestedError as e:
-            self._logger.error("UnsupportedPixelFormatRequestedError. "
-                               "Likely pixel_format is set wrong for some image request")
+            self._logger.error(
+                "UnsupportedPixelFormatRequestedError. "
+                "Likely pixel_format is set wrong for some image request"
+            )
             return None
 
         # Return
         result = []
         for i, (camera_name, image_type) in enumerate(source_types):
-            result.append(ImageEntry(camera_name=camera_name,
-                                     image_type=image_type,
-                                     image_response=image_responses[i]))
+            result.append(
+                ImageEntry(
+                    camera_name=camera_name,
+                    image_type=image_type,
+                    image_response=image_responses[i],
+                )
+            )
         return result

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -117,6 +117,41 @@ ImageWithHandBundle = namedtuple(
     "ImageBundle", ["frontleft", "frontright", "left", "right", "back", "hand"]
 )
 
+# Added to support getting images for given cameras
+IMAGE_SOURCES_BY_CAMERA = {
+    "frontleft": {
+        "visual": "frontleft_fisheye_image",
+        "depth": "frontleft_depth",
+        "depth_registered": "frontleft_depth_in_visual_frame"
+    },
+    "frontright": {
+        "visual": "frontright_fisheye_image",
+        "depth": "frontright_depth",
+        "depth_registered": "frontright_depth_in_visual_frame"
+    },
+    "left": {
+        "visual": "left_fisheye_image",
+        "depth": "left_depth",
+        "depth_registered": "left_depth_in_visual_frame"
+    },
+    "right": {
+        "visual": "right_fisheye_image",
+        "depth": "right_depth",
+        "depth_registered": "right_depth_in_visual_frame"
+    },
+    "back": {
+        "visual": "back_fisheye_image",
+        "depth": "back_depth",
+        "depth_registered": "back_depth_in_visual_frame"
+    },
+    "hand": {
+        "visual": "hand_color_image",
+        "depth": "hand_depth",
+        "depth_registered": "hand_depth_in_color_frame"
+    }
+}
+IMAGE_TYPES = {"visual", "depth", "depth_registered"}
+
 
 def robotToLocalTime(timestamp, robot):
     """Takes a timestamp and an estimated skew and return seconds and nano seconds in local time

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -2545,7 +2545,7 @@ class SpotWrapper:
 
         # Return
         result = []
-        for i in (camera_name, image_type) in enumerate(source_types):
+        for i, (camera_name, image_type) in enumerate(source_types):
             result.append(ImageEntry(camera_name=camera_name,
                                      image_type=image_type,
                                      image_response=image_responses[i]))


### PR DESCRIPTION
**Motivation:** Currently, SpotWrapper only gets images from all cameras. This impacts performance especially when the images are expensive to compute (e.g. registered depth images). It is a basic and useful feature to allow a user to specify from which camera(s) and for which image types they want the images.

**What's New:**  This PR adds an additional function to SpotWrapper, `get_images_by_cameras`.  This allows a user to:
* Specify which cameras they want to get images from (e.g. 'frontleft' and 'back')
   ```python
   spot_wrapper.get_images_by_cameras(['frontleft', 'back'])
   ``` 
   (this will get images of types RGB, depth, and depth_registered for frontleft and back cameras)

* Specify which cameras they want to get images from and what image types (e.g. 'visual' and 'depth_registered' for 'frontleft', 'visual' for 'back'):
   ```python
   spot_wrapper.get_images_by_cameras([('frontleft', ['visual', 'depth_registered']),
                                       ('back', ['visual'])])
   ```
This supports, for example, spot_ros2 to add a new parameter `cameras_used` which allows a user to select which cameras to get & publish images for.  

This PR goes together with https://github.com/bdaiinstitute/spot_ros2/pull/52