### PR TITLE
[SW-141] Checking edge cases in upload_graph

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import math
+import os
 import time
 import traceback
 import typing
@@ -812,11 +813,7 @@ class SpotWrapper:
                     )
 
             # Store the most recent knowledge of the state of the robot based on rpc calls.
-            self._current_graph = None
-            self._current_edges = dict()  # maps to_waypoint to list(from_waypoint)
-            self._current_waypoint_snapshots = dict()  # maps id to waypoint snapshot
-            self._current_edge_snapshots = dict()  # maps id to edge snapshot
-            self._current_annotation_name_to_wp_id = dict()
+            self._init_current_graph_nav_state()
 
             # Async Tasks
             self._async_task_list = []
@@ -1949,6 +1946,17 @@ class SpotWrapper:
 
     ###################################################################
 
+    def _init_current_graph_nav_state(self):
+        # Store the most recent knowledge of the state of the robot based on rpc calls.
+        self._current_graph = None
+        self._current_edges = dict()  # maps to_waypoint to list(from_waypoint)
+        self._current_waypoint_snapshots = dict()  # maps id to waypoint snapshot
+        self._current_edge_snapshots = dict()  # maps id to edge snapshot
+        self._current_annotation_name_to_wp_id = dict()
+        self._current_anchored_world_objects = dict() # maps object id to a (wo, waypoint, fiducial)
+        self._current_anchors = dict() # maps anchor id to anchor
+
+
     ## copy from spot-sdk/python/examples/graph_nav_command_line/graph_nav_command_line.py
     def _get_localization_state(self, *args):
         """Get the current localization and state of the robot."""
@@ -2035,7 +2043,7 @@ class SpotWrapper:
     def _upload_graph_and_snapshots(self, upload_filepath):
         """Upload the graph and snapshots to the robot."""
         self._logger.info("Loading the graph from disk into local storage...")
-        with open(upload_filepath + "/graph", "rb") as graph_file:
+        with open(os.path.join(upload_filepath, "graph"), "rb") as graph_file:
             # Load the graph from disk.
             data = graph_file.read()
             self._current_graph = map_pb2.Graph()
@@ -2047,25 +2055,47 @@ class SpotWrapper:
             )
         for waypoint in self._current_graph.waypoints:
             # Load the waypoint snapshots from disk.
-            with open(
-                upload_filepath + "/waypoint_snapshots/{}".format(waypoint.snapshot_id),
-                "rb",
-            ) as snapshot_file:
+            if len(waypoint.snapshot_id) == 0:
+                continue
+            waypoint_filepath = os.path.join(upload_filepath, "waypoint_snapshots", waypoint.snapshot_id)
+            if not os.path.exists(waypoint_filepath):
+                continue
+            with open(waypoint_filepath, "rb") as snapshot_file:
                 waypoint_snapshot = map_pb2.WaypointSnapshot()
                 waypoint_snapshot.ParseFromString(snapshot_file.read())
                 self._current_waypoint_snapshots[
                     waypoint_snapshot.id
                 ] = waypoint_snapshot
+
+                for fiducial in waypoint_snapshot.objects:
+                    if not fiducial.HasField("apriltag_properties"):
+                        continue
+
+                    str_id = str(fiducial.apriltag_properties.tag_id)
+                    if (str_id in self._current_anchored_world_objects and
+                            len(self._current_anchored_world_objects[str_id]) == 1):
+
+                        # Replace the placeholder tuple with a tuple of (wo, waypoint, fiducial).
+                        anchored_wo = self._current_anchored_world_objects[str_id][0]
+                        self._current_anchored_world_objects[str_id] = (anchored_wo, waypoint, fiducial)
+
         for edge in self._current_graph.edges:
             # Load the edge snapshots from disk.
-            with open(
-                upload_filepath + "/edge_snapshots/{}".format(edge.snapshot_id), "rb"
-            ) as snapshot_file:
+            if len(edge.snapshot_id) == 0:
+                continue
+            edge_filepath = os.path.join(upload_filepath, "edge_snapshots", edge.snapshot_id)
+            if not os.path.exists(edge_filepath):
+                continue
+            with open(edge_filepath, "rb") as snapshot_file:
                 edge_snapshot = map_pb2.EdgeSnapshot()
                 edge_snapshot.ParseFromString(snapshot_file.read())
                 self._current_edge_snapshots[edge_snapshot.id] = edge_snapshot
+        for anchor in self._current_graph.anchoring.anchors:
+            self._current_anchors[anchor.id] = anchor
         # Upload the graph to the robot.
         self._logger.info("Uploading the graph and snapshots to the robot...")
+        if self._lease is None:
+            self.getLease()
         self._graph_nav_client.upload_graph(
             lease=self._lease.lease_proto, graph=self._current_graph
         )
@@ -2245,7 +2275,9 @@ class SpotWrapper:
 
     def _clear_graph(self, *args):
         """Clear the state of the map on the robot, removing all waypoints and edges."""
-        return self._graph_nav_client.clear_graph(lease=self._lease.lease_proto)
+        result = self._graph_nav_client.clear_graph(lease=self._lease.lease_proto)
+        self._init_current_graph_nav_state()
+        return result
 
     @try_claim
     def toggle_power(self, should_power_on):


### PR DESCRIPTION
This PR is for part of SW-138. Adds a service for upload graph, given a file path. This PR goes together with one in bdai and one in spot_wrapper. The test is in bdai.

When the service handler is called, the following driver log happens:
```
[spot_ros2-1] [INFO] [1683815953.577940734] [Gosu.spot_ros2]: Uploading GraphNav map: /workspaces/bdai/ws/src/spot_maps/maps/bdai5picasso
[spot_ros2-1] [INFO] [1683815953.579430977] [spot_wrapper]: Loading the graph from disk into local storage...
[spot_ros2-1] [INFO] [1683815953.580826267] [spot_wrapper]: Loaded graph has 23 waypoints and 26 edges
[spot_ros2-1] [INFO] [1683815953.587187860] [spot_wrapper]: Uploading the graph and snapshots to the robot...
[spot_ros2-1] [INFO] [1683815953.877267127] [spot_wrapper]: Uploaded snapshot_edgy-egg-xQaSq54VuWCgFsWe5ByY9g==
[spot_ros2-1] [INFO] [1683815954.112413740] [spot_wrapper]: Uploaded snapshot_fuggy-kelp-oOq99bWbMLTEWBJRRv7xPw==
...
[spot_ros2-1] [INFO] [1683815958.734839673] [Gosu.spot_ros2]: Uploaded
```

For context, "upload graph" corresponds to a RPC call [in Spot SDK](https://dev.bostondynamics.com/_modules/bosdyn/client/graph_nav#GraphNavClient.upload_graph:~:text=%5Bdocs%5D-,def%20upload_graph,-(self%2C)) that uploads a map file to the GraphNav server running on Spot.