### PR TITLE
Fixes for auto claim and dataclass crash in older python versions

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -158,7 +158,7 @@ IMAGE_TYPES = {"visual", "depth", "depth_registered"}
 @dataclass(frozen=True, eq=True)
 class CameraSource:
     camera_name: str
-    image_types: list[str]
+    image_types: typing.List[str]
 
 
 @dataclass(frozen=True)
@@ -1074,12 +1074,13 @@ class SpotWrapper:
 
     def claim(self):
         """Get a lease for the robot, a handle on the estop endpoint, and the ID of the robot."""
-        for resource in self.lease:
-            if (
-                resource.resource == "all-leases"
-                and self.SPOT_CLIENT_NAME in resource.lease_owner.client_name
-            ):
-                return True, "We already claimed the lease"
+        if self.lease is not None:
+            for resource in self.lease:
+                if (
+                    resource.resource == "all-leases"
+                    and self.SPOT_CLIENT_NAME in resource.lease_owner.client_name
+                ):
+                    return True, "We already claimed the lease"
 
         try:
             self._robot_id = self._robot.get_id()


### PR DESCRIPTION
Some older versions of python which are default on 20.04 crash with one of the dataclass definitions. This requires use of the typing module in those versions (I think).

```
Traceback (most recent call last):
  File "/home/ori/frontier_ws/devel/lib/spot_driver/spot_ros", line 15, in <module>
    exec(compile(fh.read(), python_script, 'exec'), context)
  File "/home/ori/frontier_ws/src/spot_ros/spot_driver/scripts/spot_ros", line 3, in <module>
    from spot_driver.spot_ros import SpotROS
  File "/home/ori/frontier_ws/src/spot_ros/spot_driver/src/spot_driver/spot_ros.py", line 70, in <module>
    from .ros_helpers import *
  File "/home/ori/frontier_ws/src/spot_ros/spot_driver/src/spot_driver/ros_helpers.py", line 28, in <module>
    from spot_wrapper.wrapper import robotToLocalTime
  File "/home/ori/frontier_git/spot_ros/spot_wrapper/spot_wrapper/wrapper.py", line 159, in <module>
    class CameraSource:
  File "/home/ori/frontier_git/spot_ros/spot_wrapper/spot_wrapper/wrapper.py", line 161, in CameraSource
    image_types: list[str]
TypeError: 'type' object is not subscriptable
```

Also should fix the auto_claim not working by checking if the lease object is not none.