### PR TITLE
Updated bosdyn to 3.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bosdyn_core==3.2.2.post1
+bosdyn_core==3.2.3
 protobuf==4.22.1
 setuptools==45.2.0


### PR DESCRIPTION
Updating the version of `bosdyn` to 3.2.3 as upstream dependencies are breaking `bosdyn-choreography-client`. 