### PR TITLE
fix crash on startup if choreography is not installed

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -783,6 +783,7 @@ class SpotWrapper:
                             self._choreography_client = None
                     else:
                         self._choreography_client = None
+                        self._is_licensed_for_choreography = False
 
                     try:
                         self._point_cloud_client = self._robot.ensure_client(

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -764,7 +764,6 @@ class SpotWrapper:
                     )
 
                     if HAVE_CHOREOGRAPHY:
-                        self._is_licensed_for_choreography = True
                         self._sdk.register_service_client(ChoreographyClient)
                         self._choreography_client = self._robot.ensure_client(
                             ChoreographyClient.default_service_name
@@ -775,10 +774,13 @@ class SpotWrapper:
                         if not self._license_client.get_feature_enabled(
                             [ChoreographyClient.license_name]
                         )[ChoreographyClient.license_name]:
-                            self._logger.error(
-                                "Robot is not licensed for choreography", e
+                            self._logger.info(
+                                f"Robot is not licensed for choreography: {e}"
                             )
                             self._is_licensed_for_choreography = False
+                        else:
+                            self._is_licensed_for_choreography = True
+
                     else:
                         self._choreography_client = None
 
@@ -788,7 +790,9 @@ class SpotWrapper:
                         )
                     except UnregisteredServiceError:
                         self._point_cloud_client = None
-                        self._logger.info("No point cloud services are available.")
+                        self._logger.info(
+                            "No velodyne point cloud service is available."
+                        )
 
                     if self._robot.has_arm():
                         self._manipulation_api_client = self._robot.ensure_client(
@@ -796,6 +800,7 @@ class SpotWrapper:
                         )
                     else:
                         self._manipulation_api_client = None
+                        self._logger.info("Manipulation API is not available.")
 
                     initialised = True
                 except Exception as e:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -782,6 +782,7 @@ class SpotWrapper:
                             self._is_licensed_for_choreography = False
                             self._choreography_client = None
                     else:
+                        self._logger.info(f"Choreography is not available.")
                         self._choreography_client = None
                         self._is_licensed_for_choreography = False
 

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -763,8 +763,8 @@ class SpotWrapper:
                         DockingClient.default_service_name
                     )
                     self._license_client = self._robot.ensure_client(
-                            LicenseClient.default_service_name
-                            )
+                        LicenseClient.default_service_name
+                    )
 
                     if HAVE_CHOREOGRAPHY:
                         if self._license_client.get_feature_enabled(

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -764,23 +764,23 @@ class SpotWrapper:
                     )
 
                     if HAVE_CHOREOGRAPHY:
-                        self._sdk.register_service_client(ChoreographyClient)
-                        self._choreography_client = self._robot.ensure_client(
-                            ChoreographyClient.default_service_name
-                        )
                         self._license_client = self._robot.ensure_client(
                             LicenseClient.default_service_name
                         )
-                        if not self._license_client.get_feature_enabled(
+                        if self._license_client.get_feature_enabled(
                             [ChoreographyClient.license_name]
                         )[ChoreographyClient.license_name]:
+                            self._sdk.register_service_client(ChoreographyClient)
+                            self._choreography_client = self._robot.ensure_client(
+                                ChoreographyClient.default_service_name
+                            )
+                            self._is_licensed_for_choreography = True
+                        else:
                             self._logger.info(
                                 f"Robot is not licensed for choreography: {e}"
                             )
                             self._is_licensed_for_choreography = False
-                        else:
-                            self._is_licensed_for_choreography = True
-
+                            self._choreography_client = None
                     else:
                         self._choreography_client = None
 

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -762,11 +762,11 @@ class SpotWrapper:
                     self._docking_client = self._robot.ensure_client(
                         DockingClient.default_service_name
                     )
+                    self._license_client = self._robot.ensure_client(
+                            LicenseClient.default_service_name
+                            )
 
                     if HAVE_CHOREOGRAPHY:
-                        self._license_client = self._robot.ensure_client(
-                            LicenseClient.default_service_name
-                        )
                         if self._license_client.get_feature_enabled(
                             [ChoreographyClient.license_name]
                         )[ChoreographyClient.license_name]:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -58,6 +58,7 @@ try:
         load_choreography_sequence_from_txt_file,
     )
     from .spot_dance import SpotDance
+
     HAVE_CHOREOGRAPHY = True
 except ModuleNotFoundError:
     HAVE_CHOREOGRAPHY = False
@@ -766,15 +767,17 @@ class SpotWrapper:
                         self._is_licensed_for_choreography = True
                         self._sdk.register_service_client(ChoreographyClient)
                         self._choreography_client = self._robot.ensure_client(
-                                ChoreographyClient.default_service_name
-                                )
+                            ChoreographyClient.default_service_name
+                        )
                         self._license_client = self._robot.ensure_client(
-                                LicenseClient.default_service_name
-                                )
+                            LicenseClient.default_service_name
+                        )
                         if not self._license_client.get_feature_enabled(
                             [ChoreographyClient.license_name]
                         )[ChoreographyClient.license_name]:
-                            self._logger.error("Robot is not licensed for choreography", e)
+                            self._logger.error(
+                                "Robot is not licensed for choreography", e
+                            )
                             self._is_licensed_for_choreography = False
                     else:
                         self._choreography_client = None


### PR DESCRIPTION
I don't know how it is that choreography is supposed to be installed (via pip?) but if it's not installed then the startup will crash. I assume most users won't install it. This PR handles that case.

Also makes sure the manipulation client is initialised to none if there is no arm. This will still lead to crashes if you try to call manipulation commands.

I've also included this in #6.