### PR TITLE
[OC-4] added new wrappers for choreography

### DIFF
--- a/spot_wrapper/spot_dance.py
+++ b/spot_wrapper/spot_dance.py
@@ -27,6 +27,8 @@ class SpotDance:
 
     def upload_animation(self, animation_file_content : str) -> tuple[bool, str]:
         """ uploads an animation file """
+        if not self._is_licensed_for_choreography:
+            return False, "Robot is not licensed for choreography."
         # Load the animation file by saving the content to a temp file
         tmp = tempfile.NamedTemporaryFile('wb')
         with open(tmp.name, 'w') as f:
@@ -39,15 +41,11 @@ class SpotDance:
             return False, error_msg
         return True, "Success"
 
-    def execute_dance(self, data: str) -> tuple[bool, str]:
-        """uploads and executes the dance at filepath to Spot"""
-
+    def upload_dance(self, data: str) -> tuple[bool, str]:
+        """ uploads a dance """
         if not self._is_licensed_for_choreography:
             return False, "Robot is not licensed for choreography."
-        if self._robot.is_estopped():
-            error_msg = "Robot is estopped. Please use an external E-Stop client"
-            "such as the estop SDK example, to configure E-Stop."
-            return False, error_msg
+        pass
         try:
             choreography = choreography_sequence_pb2.ChoreographySequence()
             text_format.Merge(data, choreography)
@@ -68,7 +66,14 @@ class SpotDance:
                 error_msg += warn
             return False, error_msg
 
-        # Routine is valid! Power on robot and execute routine.
+    def execute_dance(self, dance_name: str) -> tuple[bool, str]:
+        """uploads and executes the dance at filepath to Spot"""
+        if not self._is_licensed_for_choreography:
+            return False, "Robot is not licensed for choreography."
+        if self._robot.is_estopped():
+            error_msg = "Robot is estopped. Please use an external E-Stop client"
+            "such as the estop SDK example, to configure E-Stop."
+            return False, error_msg
         try:
             self._robot.power_on()
             routine_name = choreography.name

--- a/spot_wrapper/spot_dance.py
+++ b/spot_wrapper/spot_dance.py
@@ -59,12 +59,10 @@ class SpotDance:
         
     def execute_dance(self, data: str) -> tuple[bool, str]:
         """ Upload and execute dance """
-        if not self._is_licensed_for_choreography:
-            return False, "Robot is not licensed for choreography."
         if self._robot.is_estopped():
             error_msg = "robot is estopped. please use an external e-stop client"
             "such as the estop sdk example, to configure e-stop."
-            return false, error_msg
+            return False, error_msg
         try:
             choreography = choreography_sequence_pb2.ChoreographySequence()
             text_format.Merge(data, choreography)
@@ -97,13 +95,12 @@ class SpotDance:
             )
             total_choreography_slices = 0
             for move in choreography.moves:
-                total_choreography_slices = 0
                 total_choreography_slices += move.requested_slices
                 estimated_time_seconds = (
                     total_choreography_slices / choreography.slices_per_minute * 60.0
                 )
             time.sleep(estimated_time_seconds)
             self._robot.power_off()
-            return True, "sucess"
+            return True, "success"
         except Exception as e:
             return False, f"Error executing dance: {e}"

--- a/spot_wrapper/spot_dance.py
+++ b/spot_wrapper/spot_dance.py
@@ -18,10 +18,12 @@ class SpotDance:
     def __init__(
         self,
         robot: Robot,
-        choreography_client: ChoreographyClient
+        choreography_client: ChoreographyClient,
+        logger
     ):
         self._robot = robot
         self._choreography_client = choreography_client
+        self._logger = logger
 
     def upload_animation(self, animation_file_content : str) -> tuple[bool, str]:
         """ uploads an animation file """
@@ -29,7 +31,7 @@ class SpotDance:
         tmp = tempfile.NamedTemporaryFile('wb')
         with open(tmp.name, 'w') as f:
             f.write(animation_file_content)
-        animation_pb = convert_animation_file_to_proto(tmp).proto
+        animation_pb = convert_animation_file_to_proto(tmp.name).proto
         try:
             upload_response = self._choreography_client.upload_animated_move(animation_pb)
         except Exception as e:
@@ -54,8 +56,6 @@ class SpotDance:
             return True, "success", moves
         except Exception as e:
             return False, f"request to choreography client for moves failed. Msg: {e}", []
-        
-
         
     def execute_dance(self, data: str) -> tuple[bool, str]:
         """ Upload and execute dance """

--- a/spot_wrapper/spot_dance.py
+++ b/spot_wrapper/spot_dance.py
@@ -18,16 +18,13 @@ class SpotDance:
     def __init__(
         self,
         robot: Robot,
-        choreography_client: ChoreographyClient,
-        is_licensed_for_choreography: bool,
+        choreography_client: ChoreographyClient
     ):
         self._robot = robot
         self._choreography_client = choreography_client
 
     def upload_animation(self, animation_file_content : str) -> tuple[bool, str]:
         """ uploads an animation file """
-        if not self._is_licensed_for_choreography:
-            return False, "Robot is not licensed for choreography."
         # Load the animation file by saving the content to a temp file
         tmp = tempfile.NamedTemporaryFile('wb')
         with open(tmp.name, 'w') as f:

--- a/spot_wrapper/spot_dance.py
+++ b/spot_wrapper/spot_dance.py
@@ -66,8 +66,8 @@ class SpotDance:
     def execute_dance(self, data: str) -> tuple[bool, str]:
         """ Upload and execute dance """
         if self._robot.is_estopped():
-            error_msg = "robot is estopped. please use an external e-stop client"
-            "such as the estop sdk example, to configure e-stop."
+            error_msg = "Robot is estopped. Please use an external E-Stop client"
+            "such as the estop SDK example, to configure E-Stop."
             return False, error_msg
         try:
             choreography = choreography_sequence_pb2.ChoreographySequence()

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -970,6 +970,7 @@ class SpotWrapper:
                 self._spot_dance = SpotDance(
                     self._robot,
                     self._choreography_client,
+                    self._logger
                 )
 
             self._robot_id = None

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1767,7 +1767,7 @@ class SpotWrapper:
                 )
                 time_to_goal: Duration = joint_move_feedback.time_to_goal
                 time_to_goal_in_seconds: float = time_to_goal.seconds + (
-                    float(time_to_goal.nanos) / float(10 ** 9)
+                    float(time_to_goal.nanos) / float(10**9)
                 )
                 time.sleep(time_to_goal_in_seconds)
                 return True, "Spot Arm moved successfully"

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -967,9 +967,7 @@ class SpotWrapper:
 
             if self._is_licensed_for_choreography:
                 self._spot_dance = SpotDance(
-                    self._robot,
-                    self._choreography_client,
-                    self._logger
+                    self._robot, self._choreography_client, self._logger
                 )
 
             self._robot_id = None
@@ -1769,7 +1767,7 @@ class SpotWrapper:
                 )
                 time_to_goal: Duration = joint_move_feedback.time_to_goal
                 time_to_goal_in_seconds: float = time_to_goal.seconds + (
-                    float(time_to_goal.nanos) / float(10**9)
+                    float(time_to_goal.nanos) / float(10 ** 9)
                 )
                 time.sleep(time_to_goal_in_seconds)
                 return True, "Spot Arm moved successfully"
@@ -2513,19 +2511,23 @@ class SpotWrapper:
         else:
             return False, "Spot is not licensed for choreography"
 
-    def upload_animation(self, animation_name : str, animation_file_content : str):
+    def upload_animation(
+        self, animation_name: str, animation_file_content: str
+    ) -> typing.Tuple[bool, str]:
         if self._is_licensed_for_choreography:
-            return self._spot_dance.upload_animation(animation_name, animation_file_content)
+            return self._spot_dance.upload_animation(
+                animation_name, animation_file_content
+            )
         else:
             return False, "Spot is not licensed for choreography"
-        
-    def list_all_moves(self):
+
+    def list_all_moves(self) -> typing.Tuple[bool, str, typing.List[str]]:
         if self._is_licensed_for_choreography:
             return self._spot_dance.list_all_moves()
         else:
             return False, "Spot is not licensed for choreography", []
-        
-    def list_all_dances(self):
+
+    def list_all_dances(self) -> typing.Tuple[bool, str, typing.List[str]]:
         if self._is_licensed_for_choreography:
             return self._spot_dance.list_all_dances()
         else:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -2514,9 +2514,9 @@ class SpotWrapper:
         else:
             return False, "Spot is not licensed for choreography"
 
-    def upload_animation(self, animation_file_content : str):
+    def upload_animation(self, animation_name : str, animation_file_content : str):
         if self._is_licensed_for_choreography:
-            return self._spot_dance.upload_animation(animation_file_content)
+            return self._spot_dance.upload_animation(animation_name, animation_file_content)
         else:
             return False, "Spot is not licensed for choreography"
         

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -55,7 +55,6 @@ from bosdyn.client import ResponseError, RpcError, create_standard_sdk
 try:
     from bosdyn.choreography.client.choreography import (
         ChoreographyClient,
-        load_choreography_sequence_from_txt_file,
     )
     from .spot_dance import SpotDance
 

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -2511,6 +2511,9 @@ class SpotWrapper:
     def execute_dance(self, filepath):
         return self._spot_dance.execute_dance(filepath)
 
+    def upload_animation(self, animation_file_content : str):
+        return self._spot_dance.upload_animation(animation_file_content)
+
     def get_docking_state(self, **kwargs):
         """Get docking state of robot."""
         state = self._docking_client.get_docking_state(**kwargs)


### PR DESCRIPTION
* added ROS2 wrappers for
1) uploading new animation files (i.e. dance moves in .cha format) 
2) fetching the list of animated moves on a robot
3) fetching the list of all choreographs on a robot 
* changed the implementation of upload_dance to upload the choreography file contents, instead of the file paths. This allows for uploading dance with the driver on a remote computer.

## Notes

## Checklist

- [x] I have broken down the change into small, reviewable sizes.
- [x] I have added appropriate tests to CI and documentation to Notion.
- [x] I certify that my change is not related to Spot functionalities or that I have already completed [appropriate hardware testing](https://github.com/bdaiinstitute/bdai/blob/main/hil_testing.md).