### PR TITLE
FeatureBranch scientific notation for large numbers

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -227,7 +227,7 @@ class HealthWrapper:
             Tuple of string and float indicating the component and its temperature in celsius
         """
         return [
-            (composite.channel_name, composite.temperature / 1000.0)
+            (composite.channel_name, composite.temperature / 1e3)
             for composite in self.client.get_temperature()
         ]
 

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1769,7 +1769,9 @@ class SpotWrapper:
                     feedback_resp.feedback.synchronized_feedback.arm_command_feedback.arm_joint_move_feedback
                 )
                 time_to_goal: Duration = joint_move_feedback.time_to_goal
-                time_to_goal_in_seconds: float = time_to_goal.seconds + time_to_goal.nanos / 1e9
+                time_to_goal_in_seconds: float = (
+                    time_to_goal.seconds + time_to_goal.nanos / 1e9
+                )
 
                 time.sleep(time_to_goal_in_seconds)
                 return True, "Spot Arm moved successfully"

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -200,7 +200,7 @@ def robotToLocalTime(timestamp, robot):
     rtime.seconds = timestamp.seconds - robot.time_sync.endpoint.clock_skew.seconds
     rtime.nanos = timestamp.nanos - robot.time_sync.endpoint.clock_skew.nanos
     if rtime.nanos < 0:
-        rtime.nanos = rtime.nanos + 1000000000
+        rtime.nanos = rtime.nanos + int(1e9)
         rtime.seconds = rtime.seconds - 1
 
     # Workaround for timestamps being incomplete
@@ -1769,9 +1769,8 @@ class SpotWrapper:
                     feedback_resp.feedback.synchronized_feedback.arm_command_feedback.arm_joint_move_feedback
                 )
                 time_to_goal: Duration = joint_move_feedback.time_to_goal
-                time_to_goal_in_seconds: float = time_to_goal.seconds + (
-                    float(time_to_goal.nanos) / float(10**9)
-                )
+                time_to_goal_in_seconds: float = time_to_goal.seconds + time_to_goal.nanos / 1e9
+
                 time.sleep(time_to_goal_in_seconds)
                 return True, "Spot Arm moved successfully"
 
@@ -1841,7 +1840,7 @@ class SpotWrapper:
                 self._robot_command_client.robot_command(robot_command)
                 self._logger.info("Force trajectory command sent")
 
-                time.sleep(float(traj_duration) + 1.0)
+                time.sleep(traj_duration + 1.0)
 
         except Exception as e:
             return False, f"Exception occured during arm movement: {e}"

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1772,7 +1772,6 @@ class SpotWrapper:
                 time_to_goal_in_seconds: float = (
                     time_to_goal.seconds + time_to_goal.nanos / 1e9
                 )
-
                 time.sleep(time_to_goal_in_seconds)
                 return True, "Spot Arm moved successfully"
 


### PR DESCRIPTION
as soon as numbers are 1e3 or bigger, counting the zeros becomes a thing. you can avoid that by using scientific notations

the scientific notation comes as a float by default so the corresponding type conversions in the code are adjusted as well