### PR TITLE
[SW-221] Correct source name for hand depth_registered

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -164,7 +164,7 @@ IMAGE_SOURCES_BY_CAMERA = {
     "hand": {
         "visual": "hand_color_image",
         "depth": "hand_depth",
-        "depth_registered": "hand_depth_in_color_frame",
+        "depth_registered": "hand_depth_in_hand_color_frame",
     },
 }
 


### PR DESCRIPTION
Correcting the source name of hand depth registerd in `IMAGE_SOURCES_BY_CAMERA`.