### PR TITLE
Fast graph uploading

### DIFF
--- a/spot_wrapper/spot_graph_nav.py
+++ b/spot_wrapper/spot_graph_nav.py
@@ -522,16 +522,30 @@ class SpotGraphNav:
             )
             return
 
-        self._graph_nav_client.upload_graph(
+        response = self._graph_nav_client.upload_graph(
             lease=self._lease.lease_proto, graph=self._current_graph
         )
         # Upload the snapshots to the robot.
-        for waypoint_snapshot in self._current_waypoint_snapshots.values():
+        for index, waypoint_snapshot_id in enumerate(
+            response.unknown_waypoint_snapshot_ids
+        ):
+            waypoint_snapshot = self._current_waypoint_snapshots[waypoint_snapshot_id]
             self._graph_nav_client.upload_waypoint_snapshot(waypoint_snapshot)
-            self._logger.info("Uploaded {}".format(waypoint_snapshot.id))
-        for edge_snapshot in self._current_edge_snapshots.values():
+            self._logger.info(
+                "Uploaded waypont snapshot {}/{} {}".format(
+                    index + 1,
+                    len(response.unknown_waypoint_snapshot_ids),
+                    waypoint_snapshot.id,
+                )
+            )
+        for index, edge_snapshot_id in enumerate(response.unknown_edge_snapshot_ids):
+            edge_snapshot = self._current_edge_snapshots[edge_snapshot_id]
             self._graph_nav_client.upload_edge_snapshot(edge_snapshot)
-            self._logger.info("Uploaded {}".format(edge_snapshot.id))
+            self._logger.info(
+                "Uploaded edge snapshot {}/{} {}".format(
+                    index + 1, len(response.unknown_edge_snapshot_ids), edge_snapshot.id
+                )
+            )
 
         # The upload is complete! Check that the robot is localized to the graph,
         # and it if is not, prompt the user to localize the robot before attempting


### PR DESCRIPTION
Current graphnav snapshots uploading code uploads all snapshots in the map even when some snapshots already exist in the robot.
This extremely takes time for uploading map.
This PR will fix this.

Tested with a robot.

For checking, I have used features of https://github.com/bdaiinstitute/spot_wrapper/pull/30 by

```python
from spot_wrapper.wrapper import SpotWrapper
import logging

logging.basicConfig(level=logging.INFO)
logger = logging.getLogger()

wrapper = SpotWrapper(username='hoge', password='fuga', hostname='192.168.50.3', robot_name='myspot', logger=logger)
wrapper.claim()

wrapper.upload_graph('path to graph')
```

with this PR. upload() method does not upload snapshots already in the robot.