### PR TITLE
Set default args to list_graph()

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1527,7 +1527,7 @@ class SpotWrapper:
             manipulation_api_feedback_request=feedback_request
         )
 
-    def list_graph(self, upload_path):
+    def list_graph(self, upload_path=None):
         """List waypoint ids of garph_nav
         Args:
           upload_path : Path to the root directory of the map.


### PR DESCRIPTION
Set default args to list_graph() so that it can be called without setting args since that arg is not used.