### PR TITLE
Add graph download/upload/clear methods

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1541,7 +1541,7 @@ class SpotWrapper:
             )
         ]
 
-    def clear_graph(self) -> tuple(bool, str):
+    def clear_graph(self) -> typing.Tuple(bool, str):
         """Clear a graph in a robot.
 
         Returns:
@@ -1554,7 +1554,7 @@ class SpotWrapper:
         except Exception as e:
             return False, f"Error: {e}"
 
-    def upload_graph(self, upload_path: str) -> tuple(bool, str):
+    def upload_graph(self, upload_path: str) -> typing.Tuple(bool, str):
         """Upload graph and snapshots to robot.
 
         Args:
@@ -1566,7 +1566,7 @@ class SpotWrapper:
         except Exception as e:
             return False, f"Error: {e}"
 
-    def download_graph(self, download_path: str) -> tuple(bool, str):
+    def download_graph(self, download_path: str) -> typing.Tuple(bool, str):
         """Download graph and snapshots from robot.
 
         Args:
@@ -2282,7 +2282,9 @@ class SpotWrapper:
             f.write(data)
             f.close()
 
-    def _download_graph_and_snapshots(self, download_path: str) -> tuple(bool, str):
+    def _download_graph_and_snapshots(
+        self, download_path: str
+    ) -> typing.Tuple(bool, str):
         """Download the graph and snapshots from the robot.
 
         Args:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1542,17 +1542,18 @@ class SpotWrapper:
         ]
 
     def clear_graph(self) -> typing.Tuple[bool, str]:
-        """Clear a graph in a robot.
+        """Clear the state of the map on the robot, removing all waypoints and edges.
 
-        Returns:
-            success (bool): success flag
-            message (str): message about result
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
         """
         try:
             self._clear_graph()
             return True, "Success"
         except Exception as e:
-            return False, f"Error: {e}"
+            return (
+                False,
+                f"Got an error while clearing a graph and snanshots in a robot: {e}",
+            )
 
     def upload_graph(self, upload_path: str) -> typing.Tuple[bool, str]:
         """Upload graph and snapshots to robot.

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1559,13 +1559,15 @@ class SpotWrapper:
         """Upload graph and snapshots to robot.
 
         Args:
-            upload_path (str): Path to the directory of the map."""
+            upload_path (str): Path to the directory of the map.
+
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message    
+        """
         try:
-            self._clear_graph()
             self._upload_graph_and_snapshots(upload_path)
             return True, "Success"
         except Exception as e:
-            return False, f"Error: {e}"
+            return False, f"Got an error while uploading a graph and snapshots to a robot: {e}"
 
     def download_graph(self, download_path: str) -> typing.Tuple[bool, str]:
         """Download graph and snapshots from robot.

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1561,19 +1561,22 @@ class SpotWrapper:
         Args:
             upload_path (str): Path to the directory of the map.
 
-        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message    
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
         """
         try:
             self._upload_graph_and_snapshots(upload_path)
             return True, "Success"
         except Exception as e:
-            return False, f"Got an error while uploading a graph and snapshots to a robot: {e}"
+            return (
+                False,
+                f"Got an error while uploading a graph and snapshots to a robot: {e}",
+            )
 
     def download_graph(self, download_path: str) -> typing.Tuple[bool, str]:
         """Download graph and snapshots from robot.
 
         Args:
-            download_path (str): Directory where graph and snapshotw are downloaded from robot.
+            download_path (str): Directory where graph and snapshots are downloaded from robot.
 
         Returns:
             success (bool): success flag
@@ -2277,7 +2280,7 @@ class SpotWrapper:
         """Write data to a file.
 
         Args:
-            filepath (str) : Path of file wher data will be written.
+            filepath (str) : Path of file where data will be written.
             data (bytes) : Bytes of data"""
         directory = os.path.dirname(filepath)
         os.makedirs(directory, exist_ok=True)
@@ -2291,7 +2294,7 @@ class SpotWrapper:
         """Download the graph and snapshots from the robot.
 
         Args:
-            download_path (str): Directory where graph and snapshotw are downloaded from robot.
+            download_path (str): Directory where graph and snapshots are downloaded from robot.
 
         Returns:
             success (bool): success flag

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1541,7 +1541,7 @@ class SpotWrapper:
             )
         ]
 
-    def clear_graph(self) -> typing.Tuple(bool, str):
+    def clear_graph(self) -> typing.Tuple[bool, str]:
         """Clear a graph in a robot.
 
         Returns:
@@ -1554,7 +1554,7 @@ class SpotWrapper:
         except Exception as e:
             return False, f"Error: {e}"
 
-    def upload_graph(self, upload_path: str) -> typing.Tuple(bool, str):
+    def upload_graph(self, upload_path: str) -> typing.Tuple[bool, str]:
         """Upload graph and snapshots to robot.
 
         Args:
@@ -1566,7 +1566,7 @@ class SpotWrapper:
         except Exception as e:
             return False, f"Error: {e}"
 
-    def download_graph(self, download_path: str) -> typing.Tuple(bool, str):
+    def download_graph(self, download_path: str) -> typing.Tuple[bool, str]:
         """Download graph and snapshots from robot.
 
         Args:
@@ -2284,7 +2284,7 @@ class SpotWrapper:
 
     def _download_graph_and_snapshots(
         self, download_path: str
-    ) -> typing.Tuple(bool, str):
+    ) -> typing.Tuple[bool, str]:
         """Download the graph and snapshots from the robot.
 
         Args:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1542,7 +1542,7 @@ class SpotWrapper:
         ]
 
     def clear_graph(self) -> typing.Tuple[bool, str]:
-        """Clear the state of the map on the robot, removing all waypoints and edges.
+        """Clear the state of the map on the robot, removing all waypoints and edges in the RAM of the robot.
 
         Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
         """
@@ -1556,7 +1556,10 @@ class SpotWrapper:
             )
 
     def upload_graph(self, upload_path: str) -> typing.Tuple[bool, str]:
-        """Upload the specified graph and snapshots from local to a robot. graph and snapshots are placed like
+        """Upload the specified graph and snapshots from local to a robot.
+
+        While this method, if there are snapshots already in the robot, they will be loaded from the robot's disk without uploading.
+        Graph and snapshots to be uploaded should be placed like
 
         Directory specified with upload_path arg
           |
@@ -2506,7 +2509,7 @@ class SpotWrapper:
                 self.toggle_power(should_power_on=False)
 
     def _clear_graph(self, *args):
-        """Clear the state of the map on the robot, removing all waypoints and edges."""
+        """Clear the state of the map on the robot, removing all waypoints and edges in the RAM of the robot."""
         result = self._graph_nav_client.clear_graph(lease=self._lease.lease_proto)
         self._init_current_graph_nav_state()
         return result

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1553,10 +1553,10 @@ class SpotWrapper:
             return True, "Success"
         except Exception as e:
             return False, f"Error: {e}"
-        
+
     def upload_graph(self, upload_path: str) -> tuple(bool, str):
         """Upload graph and snapshots to robot.
-        
+
         Args:
             upload_path (str): Path to the directory of the map."""
         try:
@@ -1577,7 +1577,9 @@ class SpotWrapper:
             message (str): message about result
         """
         try:
-            success, message = self._download_graph_and_snapshots(download_path=download_path)
+            success, message = self._download_graph_and_snapshots(
+                download_path=download_path
+            )
             return success, message
         except Exception as e:
             return False, f"Error: {e}"
@@ -2270,7 +2272,7 @@ class SpotWrapper:
 
     def _write_bytes_while_download(self, filepath: str, data: bytes):
         """Write data to a file.
-        
+
         Args:
             filepath (str) : Path of file wher data will be written.
             data (bytes) : Bytes of data"""
@@ -2282,10 +2284,10 @@ class SpotWrapper:
 
     def _download_graph_and_snapshots(self, download_path: str) -> tuple(bool, str):
         """Download the graph and snapshots from the robot.
-        
+
         Args:
             download_path (str): Directory where graph and snapshotw are downloaded from robot.
-            
+
         Returns:
             success (bool): success flag
             message (str): message"""
@@ -2294,8 +2296,7 @@ class SpotWrapper:
             return False, "Failed to download the graph."
         graph_bytes = graph.SerializeToString()
         self._write_bytes_while_download(
-            os.path.join(download_path, "graph"),
-            graph_bytes
+            os.path.join(download_path, "graph"), graph_bytes
         )
         # Download the waypoint and edge snapshots.
         for waypoint in graph.waypoints:
@@ -2304,14 +2305,12 @@ class SpotWrapper:
                     waypoint.snapshot_id
                 )
             except Exception:
-                self.logger.warn("Failed to download waypoint snapshot: %s", waypoint.snapshot_id)
+                self.logger.warn(
+                    "Failed to download waypoint snapshot: %s", waypoint.snapshot_id
+                )
                 continue
             self._write_bytes_while_download(
-                os.path.join(
-                    download_path,
-                    "waypoint_snapshots",
-                    waypoint.snapshot_id
-                ),
+                os.path.join(download_path, "waypoint_snapshots", waypoint.snapshot_id),
                 waypoint_snapshot.SerializeToString(),
             )
         for edge in graph.edges:
@@ -2320,14 +2319,12 @@ class SpotWrapper:
                     edge.snapshot_id
                 )
             except Exception:
-                self.logger.warn("Failed to download edge snapshot: %s", edge.snapshot_id)
+                self.logger.warn(
+                    "Failed to download edge snapshot: %s", edge.snapshot_id
+                )
                 continue
             self._write_bytes_while_download(
-                os.path.join(
-                    download_path,
-                    "edge_snapshots",
-                    edge.snapshot_id
-                ),
+                os.path.join(download_path, "edge_snapshots", edge.snapshot_id),
                 edge_snapshot.SerializeToString(),
             )
         return True, "Success"

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -2239,7 +2239,7 @@ class SpotWrapper:
             f.write(data)
             f.close()
 
-    def _download_full_graph_from_robot(self, download_path: str):
+    def _download_graph_and_snapshots(self, download_path: str) -> tuple(bool, str):
         """Download the graph and snapshots from the robot.
         
         Args:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1585,14 +1585,12 @@ class SpotWrapper:
             )
 
     def download_graph(self, download_path: str) -> typing.Tuple[bool, str]:
-        """Download graph and snapshots from robot.
+        """Download current graph and snapshots in the robot to the specified directory.
 
         Args:
             download_path (str): Directory where graph and snapshots are downloaded from robot.
 
-        Returns:
-            success (bool): success flag
-            message (str): message about result
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
         """
         try:
             success, message = self._download_graph_and_snapshots(
@@ -1600,7 +1598,10 @@ class SpotWrapper:
             )
             return success, message
         except Exception as e:
-            return False, f"Error: {e}"
+            return (
+                False,
+                f"Got an error during downloading graph and snapshots from the robot: {e}",
+            )
 
     @try_claim
     def navigate_to(

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1541,6 +1541,47 @@ class SpotWrapper:
             )
         ]
 
+    def clear_graph(self) -> tuple(bool, str):
+        """Clear a graph in a robot.
+
+        Returns:
+            success (bool): success flag
+            message (str): message about result
+        """
+        try:
+            self._clear_graph()
+            return True, "Success"
+        except Exception as e:
+            return False, f"Error: {e}"
+        
+    def upload_graph(self, upload_path: str) -> tuple(bool, str):
+        """Upload graph and snapshots to robot.
+        
+        Args:
+            upload_path (str): Path to the directory of the map."""
+        try:
+            self._clear_graph()
+            self._upload_graph_and_snapshots(upload_path)
+            return True, "Success"
+        except Exception as e:
+            return False, f"Error: {e}"
+
+    def download_graph(self, download_path: str) -> tuple(bool, str):
+        """Download graph and snapshots from robot.
+
+        Args:
+            download_path (str): Directory where graph and snapshotw are downloaded from robot.
+
+        Returns:
+            success (bool): success flag
+            message (str): message about result
+        """
+        try:
+            success, message = self._download_graph_and_snapshots(download_path=download_path)
+            return success, message
+        except Exception as e:
+            return False, f"Error: {e}"
+
     @try_claim
     def navigate_to(
         self,

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1556,7 +1556,19 @@ class SpotWrapper:
             )
 
     def upload_graph(self, upload_path: str) -> typing.Tuple[bool, str]:
-        """Upload graph and snapshots to robot.
+        """Upload the specified graph and snapshots from local to a robot. graph and snapshots are placed like
+
+        Directory specified with upload_path arg
+          |
+          +-- graph
+          |
+          +-- waypoint_snapshots/
+          |     |
+          |     +-- waypont snapshot files
+          |
+          +-- edge_snapshots/
+                |
+                +-- edge snapshot files
 
         Args:
             upload_path (str): Path to the directory of the map.


### PR DESCRIPTION
- Add graph downloading methods
- Add public methods for clearing, uploading and downloading graph methods

Checked with a robot like

```python
from spot_wrapper.wrapper import SpotWrapper
import logging

logging.basicConfig(level=logging.INFO)
logger = logging.getLogger()

wrapper = SpotWrapper(username='hoge', password='fuga', hostname='192.168.50.3', robot_name='myspot', logger=logger)
wrapper.claim()

wrapper.upload_graph('path to graph')
wrapper.list_graph(None)
wrapper.download_graph('directory for downloading')
wrapper.clear_graph()
wrapper.list_graph(None)
```

Errors will show up during `list_graph` method. This will be fixed with https://github.com/bdaiinstitute/spot_wrapper/pull/31