### PR TITLE
Add CODEOWNERS file for visibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners
+* @jbarry-bdai @heuristicus @amessing-bdai


### PR DESCRIPTION
This is more for visibility than marking ownership. If someone external to one of our organizations makes a PR, we will automatically be put on as reviewers and can point the correct person to review it (if it is not one of us). Who else should be added to the list?