### PR TITLE
[N/A] Fixed protobuf enum typehint

### DIFF
--- a/spot_wrapper/spot_world_objects.py
+++ b/spot_wrapper/spot_world_objects.py
@@ -2,10 +2,14 @@ import logging
 import typing
 
 from bosdyn.api.world_object_pb2 import ListWorldObjectResponse
-from bosdyn.api.world_object_pb2 import WorldObjectType
 from bosdyn.client.async_tasks import AsyncPeriodicQuery
 from bosdyn.client.common import FutureWrapper
 from bosdyn.client.world_object import WorldObjectClient
+
+
+# This represents the WorldObjectType from bosdyn.api.world_object_pb2, which is an enum in the protobuf file.
+# In python, WorldObjectType is an EnumTypeWrapper object and thus cannot be used as a typehint
+WorldObjectType = typing.TypeVar("WorldObjectType")
 
 
 class AsyncWorldObjects(AsyncPeriodicQuery):


### PR DESCRIPTION
Didn't retest after the last commit from #34 as it just added typehints. When a protobuf enum type is converted to python, it is not created as a python type but as an EnumTypeWrapper **object** and thus cannot be used in typehints (this is explained in a comment in this PR too). This fixes that oversite.