### PR TITLE
Implement MediaLog functions for spot cam

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -450,9 +450,9 @@ class MediaLogWrapper:
         """
         # TODO: What does this return if the logpoint doesn't exist? Just an empty logpoint?
         if raw:
-            return self.client.retrieve_raw_data(Logpoint(name))
+            return self.client.retrieve_raw_data(logpoint=Logpoint(name))
         else:
-            return self.client.retrieve(Logpoint(name))
+            return self.client.retrieve(logpoint=Logpoint(name))
 
     def get_logpoint_status(self, name: str) -> Logpoint.LogStatus:
         """
@@ -466,7 +466,7 @@ class MediaLogWrapper:
         Returns:
             Status of the logpoint
         """
-        return self.client.get_status(Logpoint(name))
+        return self.client.get_status(logpoint=Logpoint(name))
 
     def delete_logpoint(self, name: str) -> None:
         """
@@ -475,7 +475,7 @@ class MediaLogWrapper:
         Args:
             name: Delete this logpoint
         """
-        self.client.delete(Logpoint(name))
+        self.client.delete(logpoint=Logpoint(name))
 
     def store(
         self, camera: SpotCamCamera, tag: typing.Optional[str] = None

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -491,7 +491,7 @@ class MediaLogWrapper:
             Logpoint containing information about the stored data
         """
         return self.client.store(
-            camera=Camera(name=camera.name.lower()), record_type=Logpoint.STILLIMAGE, tag=tag
+            camera=Camera(name=camera.value), record_type=Logpoint.STILLIMAGE, tag=tag
         )
 
     def tag(self, name: str, tag: str) -> None:

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -602,7 +602,7 @@ class MediaLogWrapper:
         # The original method saves the image to file first, then reads and saves it in a different way if rgb24 is
         # not requested, so we do it the same way. There's probably a better way to do it.  Maybe frombytes with the
         # raw option?
-        with open(full_path, "w") as f:
+        with open(full_path, "wb") as f:
             f.write(image)
 
         if not use_rgb24:

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -491,7 +491,7 @@ class MediaLogWrapper:
             Logpoint containing information about the stored data
         """
         return self.client.store(
-            camera=Camera(name=camera.name), record_type=Logpoint.STILLIMAGE, tag=tag
+            camera=Camera(name=camera.name.lower()), record_type=Logpoint.STILLIMAGE, tag=tag
         )
 
     def tag(self, name: str, tag: str) -> None:

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -450,9 +450,9 @@ class MediaLogWrapper:
         """
         # TODO: What does this return if the logpoint doesn't exist? Just an empty logpoint?
         if raw:
-            return self.client.retrieve_raw_data(logpoint=Logpoint(name))
+            return self.client.retrieve_raw_data(logpoint=Logpoint(name=name))
         else:
-            return self.client.retrieve(logpoint=Logpoint(name))
+            return self.client.retrieve(logpoint=Logpoint(name=name))
 
     def get_logpoint_status(self, name: str) -> Logpoint.LogStatus:
         """
@@ -466,7 +466,7 @@ class MediaLogWrapper:
         Returns:
             Status of the logpoint
         """
-        return self.client.get_status(logpoint=Logpoint(name))
+        return self.client.get_status(logpoint=Logpoint(name=name))
 
     def delete_logpoint(self, name: str) -> None:
         """
@@ -475,7 +475,7 @@ class MediaLogWrapper:
         Args:
             name: Delete this logpoint
         """
-        self.client.delete(logpoint=Logpoint(name))
+        self.client.delete(logpoint=Logpoint(name=name))
 
     def store(
         self, camera: SpotCamCamera, tag: typing.Optional[str] = None

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -491,7 +491,7 @@ class MediaLogWrapper:
             Logpoint containing information about the stored data
         """
         return self.client.store(
-            camera=Camera(type=camera), record_type=Logpoint.STILLIMAGE, tag=tag
+            camera=Camera(name=camera), record_type=Logpoint.STILLIMAGE, tag=tag
         )
 
     def tag(self, name: str, tag: str) -> None:

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -610,15 +610,21 @@ class MediaLogWrapper:
                 data = fd.read()
 
             mode = "RGB"
-            image = Image.frombuffer(
-                mode,
-                (logpoint.image_params.width, logpoint.image_params.height),
-                data,
-                "raw",
-                mode,
-                0,
-                1,
-            )
+            try:
+                image = Image.frombuffer(
+                    mode,
+                    (logpoint.image_params.width, logpoint.image_params.height),
+                    data,
+                    "raw",
+                    mode,
+                    0,
+                    1,
+                )
+            except ValueError as e:
+                self.logger.error(
+                    f"Error while trying to save image as png: {e}. You may need to restart the camera to fix this."
+                )
+
             os.remove(full_path)  # remove the rgb24 image
             full_path = os.path.join(
                 save_path,

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -554,7 +554,7 @@ class MediaLogWrapper:
             base_filename: Use this filename as the base name for the image file
             raw: If true, retrieve raw data rather than processed data. Useful for IR images?
             camera: If set, add the name of the camera to the output filename. The logpoint doesn't store this information
-            use_rgb24: If set, save ptz image in .rgb24 format. By default it is saved to jpg
+            use_rgb24: If set, save the ptz image in .rgb24 format without compression. By default it is saved to png
 
         Returns:
             Filename the image was saved to, or None if saving failed
@@ -622,7 +622,7 @@ class MediaLogWrapper:
             os.remove(full_path)  # remove the rgb24 image
             full_path = os.path.join(
                 save_path,
-                self._build_filename(logpoint, base_filename, ".jpg", camera),
+                self._build_filename(logpoint, base_filename, ".png", camera),
             )
             image.save(full_path)
 
@@ -652,7 +652,7 @@ class MediaLogWrapper:
             logpoint.name,
             path,
             base_filename,
-            raw=camera == SpotCamCamera.IR,
+            raw=False,
             camera=camera,
         )
 

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -491,7 +491,7 @@ class MediaLogWrapper:
             Logpoint containing information about the stored data
         """
         return self.client.store(
-            camera=Camera(name=camera), record_type=Logpoint.STILLIMAGE, tag=tag
+            camera=Camera(name=camera.name), record_type=Logpoint.STILLIMAGE, tag=tag
         )
 
     def tag(self, name: str, tag: str) -> None:

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -2,6 +2,8 @@ import asyncio
 import datetime
 import enum
 import os.path
+import pathlib
+import shutil
 import threading
 import typing
 import wave
@@ -9,20 +11,25 @@ import wave
 import bosdyn.client
 import cv2
 import numpy as np
+from PIL import Image
 from aiortc import RTCConfiguration
+from bosdyn.api import image_pb2
+from bosdyn.api.data_chunk_pb2 import DataChunk
+from bosdyn.api.spot_cam import audio_pb2
+from bosdyn.api.spot_cam.camera_pb2 import Camera
+from bosdyn.api.spot_cam.logging_pb2 import Logpoint
+from bosdyn.api.spot_cam.ptz_pb2 import PtzDescription, PtzVelocity, PtzPosition
 from bosdyn.client import Robot
 from bosdyn.client import spot_cam
-from bosdyn.client.spot_cam.compositor import CompositorClient
-from bosdyn.client.spot_cam.lighting import LightingClient
-from bosdyn.client.spot_cam.power import PowerClient
-from bosdyn.client.spot_cam.health import HealthClient
-from bosdyn.client.spot_cam.audio import AudioClient
-from bosdyn.client.spot_cam.streamquality import StreamQualityClient
-from bosdyn.client.spot_cam.ptz import PtzClient
-from bosdyn.client.spot_cam.media_log import MediaLogClient
 from bosdyn.client.payload import PayloadClient
-from bosdyn.api.spot_cam.ptz_pb2 import PtzDescription, PtzVelocity, PtzPosition
-from bosdyn.api.spot_cam import audio_pb2
+from bosdyn.client.spot_cam.audio import AudioClient
+from bosdyn.client.spot_cam.compositor import CompositorClient
+from bosdyn.client.spot_cam.health import HealthClient
+from bosdyn.client.spot_cam.lighting import LightingClient
+from bosdyn.client.spot_cam.media_log import MediaLogClient
+from bosdyn.client.spot_cam.power import PowerClient
+from bosdyn.client.spot_cam.ptz import PtzClient
+from bosdyn.client.spot_cam.streamquality import StreamQualityClient
 
 from spot_wrapper.cam_webrtc_client import WebRTCClient
 from spot_wrapper.wrapper import SpotWrapper
@@ -374,22 +381,255 @@ class StreamQualityWrapper:
         self.client.enable_congestion_control(enable)
 
 
-class MediaLogWrapper:
+class SpotCamCamera(enum.Enum):
     """
-    Wrapper for interacting with the media log. And importantly, information about the cameras themselves
+    More obvious names for the spot cam cameras
     """
 
-    def __init__(self, robot, logger):
+    PANORAMIC = "pano"
+    PTZ = "ptz"
+    IR = "ir"
+    REAR_LEFT_PANO = "c0"
+    FRONT_LEFT_PANO = "c1"
+    FRONT_PANO = "c2"
+    FRONT_RIGHT_PANO = "c3"
+    REAR_RIGHT_PANO = "c4"
+
+
+class MediaLogWrapper:
+    """
+    Wrapper for interacting with the media log. Allows saving of images from the camera to logpoints for full
+    resolution high quality imaging. Importantly, also has information about the cameras available.
+
+    Some functionality adapted from https://github.com/boston-dynamics/spot-sdk/blob/master/python/examples/spot_cam/media_log.py
+    """
+
+    def __init__(self, robot, logger) -> None:
         self.client: MediaLogClient = robot.ensure_client(
             MediaLogClient.default_service_name
         )
         self.logger = logger
 
-    def list_cameras(self) -> typing.List:
+    def list_cameras(self) -> typing.List[Camera]:
         """
         List the cameras on the spot cam
         """
         return self.client.list_cameras()
+
+    def list_logpoints(self) -> typing.List[Logpoint]:
+        """
+        List logpoints stored on the camera
+
+        Returns:
+            List of logpoints
+        """
+        return self.client.list_logpoints()
+
+    def retrieve_logpoint(
+        self, name: str, raw: bool = False
+    ) -> typing.Tuple[Logpoint, DataChunk]:
+        """
+        Retrieve a logpoint from the camera
+
+        Args:
+            name: Name of the logpoint to retrieve
+            raw: If true, retrieve raw data from the logpoint. Generally used for IR? See
+                 https://github.com/boston-dynamics/spot-sdk/blob/aa607fec2e32f880ad55da8bf186ce1b3384c891/python/examples/spot_cam/media_log.py#L168-L171
+
+        Returns:
+            Logpoint with the given name, or None if it doesn't exist
+        """
+        # TODO: What does this return if the logpoint doesn't exist? Just an empty logpoint?
+        if raw:
+            return self.client.retrieve_raw_data(Logpoint(name))
+        else:
+            return self.client.retrieve(Logpoint(name))
+
+    def get_logpoint_status(self, name: str) -> Logpoint.LogStatus:
+        """
+        Get the status of the logpoint
+
+        https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html?highlight=listlogpoints#logpoint-logstatus
+
+        Args:
+            name: Retrieve the status for the logpoint with this name
+
+        Returns:
+            Status of the logpoint
+        """
+        return self.client.get_status(Logpoint(name))
+
+    def delete_logpoint(self, name: str) -> None:
+        """
+        Delete a logpoint from the camera
+
+        Args:
+            name: Delete this logpoint
+        """
+        self.client.delete(Logpoint(name))
+
+    def store(
+        self, camera: SpotCamCamera, tag: typing.Optional[str] = None
+    ) -> Logpoint:
+        """
+        Take a snapshot of the data currently on the given camera and store it to a logpoint.
+
+        Args:
+            camera: Camera for which a logpoint should be recorded
+            tag: Optional tag to associate with the logpoint
+
+        Returns:
+            Logpoint containing information about the stored data
+        """
+        return self.client.store(
+            camera=Camera(type=camera), record_type=Logpoint.STILLIMAGE, tag=tag
+        )
+
+    def tag(self, name: str, tag: str) -> None:
+        """
+        Update the tag of the given logpoint
+
+        Args:
+            name: Name of the Logpoint for which the tag should be updated
+            tag: New tag for the Logpoint
+        """
+        self.client.tag(logpoint=Logpoint(name=name, tag=tag))
+
+    def _build_filename(
+        self,
+        logpoint: Logpoint,
+        filename: str,
+        extension: str,
+        camera: typing.Optional[SpotCamCamera] = None,
+    ) -> str:
+        """
+        Build a filename from a base name. Returns files of the form basefilename_cameraname_iso_date
+
+
+        Args:
+
+
+        Returns:
+
+
+        """
+        if not extension.startswith("."):
+            extension = f".{extension}"
+
+        log_time = datetime.datetime.fromtimestamp(logpoint.timestamp.seconds)
+        log_time.replace(microsecond=int(logpoint.timestamp.nanos * 0.001))
+        if camera:
+            return f"{filename}_{camera.name}_{log_time.isoformat()}{extension}"
+        else:
+            return f"{filename}_{log_time.isoformat()}{extension}"
+
+    def save_logpoint_image(
+        self,
+        name: str,
+        path: str,
+        filename: str,
+        raw: bool = False,
+        camera: typing.Optional[SpotCamCamera] = None,
+    ) -> typing.Optional[str]:
+        """
+        Save the data in a logpoint to the given file on the caller's local machine.
+
+        Args:
+            name: Save the image associated with this logpoint
+            path: Save the data to this directory
+            filename: Use this filename as the base name for the image file
+            raw: If true, retrieve raw data rather than processed data. Useful for IR images?
+            camera: If set, add the name of the camera to the output filename. The logpoint doesn't store this information
+
+        Returns:
+            Filename the image was saved to, or None if saving failed
+        """
+
+        logpoint, image = self.retrieve_logpoint(name, raw=raw)
+
+        save_path = os.path.abspath(os.path.expanduser(path))
+
+        if not os.path.isdir(save_path):
+            pathlib.Path(save_path).mkdir(parents=True, exist_ok=True)
+
+        # Special case for 16 bit raw thermal image
+        if logpoint.image_params.format == image_pb2.Image.PIXEL_FORMAT_GREYSCALE_U16:
+            np_img = np.frombuffer(image, dtype=np.uint16).byteswap()
+            np_img = np_img.reshape(
+                (logpoint.image_params.height, logpoint.image_params.width, 1)
+            )
+            full_path = os.path.join(
+                save_path,
+                self._build_filename(logpoint, filename, ".pgm", SpotCamCamera.IR),
+            )
+            cv2.imwrite(full_path, np_img)
+            return full_path
+
+        # Pano and IR both come in as JPEG from retrieve command
+        if (
+            logpoint.image_params.height == 4800
+            or logpoint.image_params.height == 2400
+            or (
+                logpoint.image_params.width == 640
+                and logpoint.image_params.height == 512
+            )
+        ):
+            full_path = os.path.join(
+                save_path,
+                self._build_filename(logpoint, filename, ".jpg", camera),
+            )
+        else:
+            full_path = os.path.join(
+                save_path,
+                self._build_filename(logpoint, filename, ".rgb24", camera),
+            )
+
+            if not options.save_as_rgb24:
+                with open(target_filename, mode="rb") as fd:
+                    data = fd.read()
+
+                mode = "RGB"
+                image = Image.frombuffer(
+                    mode,
+                    (logpoint.image_params.width, logpoint.image_params.height),
+                    data,
+                    "raw",
+                    mode,
+                    0,
+                    1,
+                )
+                image.save(f"{filename}.jpg")
+
+                os.remove(target_filename)
+
+        return logpoint
+
+    def store_and_save_image(
+        self, camera: SpotCamCamera, path: str, base_filename: str
+    ) -> typing.Optional[str]:
+        """
+        Stores a logpoint and saves the data to the given path on the caller's local machine.
+
+        Args:
+            camera: Camera from which data should be saved
+            path: Save the data to this directory
+            base_filename: Use this as the base name of the saved file
+
+        Returns:
+            File the image was saved to, or None if saving failed
+        """
+        logpoint = self.store(camera)
+        # Wait until the data is stored on disk before attempting a save
+        while self.get_logpoint_status(logpoint.name) != Logpoint.COMPLETE:
+            logpoint = self.get_logpoint_status(logpoint.name)
+
+        return self.save_logpoint_image(
+            logpoint.name,
+            path,
+            base_filename,
+            raw=camera == SpotCamCamera.IR,
+            camera=camera,
+        )
 
 
 class PTZWrapper:
@@ -542,7 +782,10 @@ class PTZWrapper:
 
 class ImageStreamWrapper:
     """
-    A wrapper for the image stream from WebRTC
+    A wrapper for the image stream from WebRTC.
+
+    It's not recommended to use images from this image stream for anything beyond casual viewing as they are heavily
+    compressed. Prefer use of MediaLog methods to get uncompressed high resolution images.
 
     Can view the same stream at https://192.168.50.3:31102/h264.sdp.html (depending on the IP of the robot)
 

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -644,7 +644,7 @@ class MediaLogWrapper:
         """
         logpoint = self.store(camera)
         # Wait until the data is stored on disk before attempting a save
-        while self.get_logpoint_status(logpoint.name) != Logpoint.COMPLETE:
+        while self.get_logpoint_status(logpoint.name).status != Logpoint.COMPLETE:
             logpoint = self.get_logpoint_status(logpoint.name)
 
         return self.save_logpoint_image(

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -527,9 +527,9 @@ class MediaLogWrapper:
 
     def save_logpoint_image(
         self,
-        name: str,
+        logpoint_name: str,
         path: str,
-        filename: str,
+        base_filename: str,
         raw: bool = False,
         camera: typing.Optional[SpotCamCamera] = None,
         use_rgb24: bool = False,
@@ -540,9 +540,9 @@ class MediaLogWrapper:
         Adapted from https://github.com/boston-dynamics/spot-sdk/blob/aa607fec2e32f880ad55da8bf186ce1b3384c891/python/examples/spot_cam/media_log.py#L166-L206
 
         Args:
-            name: Save the image associated with this logpoint
+            logpoint_name: Save the image associated with this logpoint
             path: Save the data to this directory
-            filename: Use this filename as the base name for the image file
+            base_filename: Use this filename as the base name for the image file
             raw: If true, retrieve raw data rather than processed data. Useful for IR images?
             camera: If set, add the name of the camera to the output filename. The logpoint doesn't store this information
             use_rgb24: If set, save ptz image in .rgb24 format. By default it is saved to jpg
@@ -551,7 +551,7 @@ class MediaLogWrapper:
             Filename the image was saved to, or None if saving failed
         """
 
-        logpoint, image = self.retrieve_logpoint(name, raw=raw)
+        logpoint, image = self.retrieve_logpoint(logpoint_name, raw=raw)
 
         save_path = os.path.abspath(os.path.expanduser(path))
 
@@ -566,7 +566,7 @@ class MediaLogWrapper:
             )
             full_path = os.path.join(
                 save_path,
-                self._build_filename(logpoint, filename, ".pgm", SpotCamCamera.IR),
+                self._build_filename(logpoint, base_filename, ".pgm", SpotCamCamera.IR),
             )
             cv2.imwrite(full_path, np_img)
             return full_path
@@ -582,12 +582,12 @@ class MediaLogWrapper:
         ):
             full_path = os.path.join(
                 save_path,
-                self._build_filename(logpoint, filename, ".jpg", camera),
+                self._build_filename(logpoint, base_filename, ".jpg", camera),
             )
         else:
             full_path = os.path.join(
                 save_path,
-                self._build_filename(logpoint, filename, ".rgb24", camera),
+                self._build_filename(logpoint, base_filename, ".rgb24", camera),
             )
 
         # The original method saves the image to file first, then reads and saves it in a different way if rgb24 is
@@ -612,7 +612,7 @@ class MediaLogWrapper:
             )
             full_path = os.path.join(
                 save_path,
-                self._build_filename(logpoint, filename, ".jpg", camera),
+                self._build_filename(logpoint, base_filename, ".jpg", camera),
             )
             image.save(full_path)
 
@@ -622,7 +622,8 @@ class MediaLogWrapper:
         self, camera: SpotCamCamera, path: str, base_filename: str
     ) -> typing.Optional[str]:
         """
-        Stores a logpoint and saves the data to the given path on the caller's local machine.
+        Stores a logpoint and saves the data to the given path on the caller's local machine. Blocks until the image
+        is ready to be saved.
 
         Args:
             camera: Camera from which data should be saved

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -619,6 +619,7 @@ class MediaLogWrapper:
                 0,
                 1,
             )
+            os.remove(full_path)  # remove the rgb24 image
             full_path = os.path.join(
                 save_path,
                 self._build_filename(logpoint, base_filename, ".jpg", camera),

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -629,7 +629,7 @@ class MediaLogWrapper:
         return logpoint
 
     def store_and_save_image(
-        self, camera: SpotCamCamera, path: str, base_filename: str
+        self, camera: SpotCamCamera, path: str, base_filename: str, delete: bool = True
     ) -> typing.Optional[str]:
         """
         Stores a logpoint and saves the data to the given path on the caller's local machine. Blocks until the image
@@ -639,6 +639,7 @@ class MediaLogWrapper:
             camera: Camera from which data should be saved
             path: Save the data to this directory
             base_filename: Use this as the base name of the saved file
+            delete: If true, delete the logpoint which is created after saving the image
 
         Returns:
             File the image was saved to, or None if saving failed
@@ -648,13 +649,19 @@ class MediaLogWrapper:
         while self.get_logpoint_status(logpoint.name).status != Logpoint.COMPLETE:
             logpoint = self.get_logpoint_status(logpoint.name)
 
-        return self.save_logpoint_image(
+        output_fname = self.save_logpoint_image(
             logpoint.name,
             path,
             base_filename,
             raw=False,
             camera=camera,
         )
+
+        if delete:
+            # Since we have saved the logpoint image, can probably safely delete it
+            self.delete_logpoint(logpoint.name)
+
+        return output_fname
 
 
 class PTZWrapper:

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -593,11 +593,14 @@ class MediaLogWrapper:
                 save_path,
                 self._build_filename(logpoint, base_filename, ".jpg", camera),
             )
+            # If we're saving as jpg we don't want to rewrite the image file with use_rgb24
+            jpg = True
         else:
             full_path = os.path.join(
                 save_path,
                 self._build_filename(logpoint, base_filename, ".rgb24", camera),
             )
+            jpg = False
 
         # The original method saves the image to file first, then reads and saves it in a different way if rgb24 is
         # not requested, so we do it the same way. There's probably a better way to do it.  Maybe frombytes with the
@@ -605,7 +608,7 @@ class MediaLogWrapper:
         with open(full_path, "wb") as f:
             f.write(image)
 
-        if not use_rgb24:
+        if not jpg and not use_rgb24:
             with open(full_path, mode="rb") as fd:
                 data = fd.read()
 
@@ -624,6 +627,7 @@ class MediaLogWrapper:
                 self.logger.error(
                     f"Error while trying to save image as png: {e}. You may need to restart the camera to fix this."
                 )
+                return None
 
             os.remove(full_path)  # remove the rgb24 image
             full_path = os.path.join(

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -770,13 +770,11 @@ class SpotWrapper:
                             ChoreographyClient.default_service_name
                         )
                     else:
-                        self._logger.info(
-                            f"Robot is not licensed for choreography: {e}"
-                        )
+                        self._logger.info("Robot is not licensed for choreography")
                         self._is_licensed_for_choreography = False
                         self._choreography_client = None
                 else:
-                    self._logger.info(f"Choreography is not available.")
+                    self._logger.info("Choreography is not available.")
                     self._choreography_client = None
                     self._is_licensed_for_choreography = False
 

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1631,6 +1631,71 @@ class SpotWrapper:
             )
         ]
 
+    def clear_graph(self) -> typing.Tuple[bool, str]:
+        """Clear the state of the map on the robot, removing all waypoints and edges in the RAM of the robot.
+
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
+        """
+        try:
+            self._clear_graph()
+            return True, "Success"
+        except Exception as e:
+            return (
+                False,
+                f"Got an error while clearing a graph and snanshots in a robot: {e}",
+            )
+
+    def upload_graph(self, upload_path: str) -> typing.Tuple[bool, str]:
+        """Upload the specified graph and snapshots from local to a robot.
+
+        While this method, if there are snapshots already in the robot, they will be loaded from the robot's disk without uploading.
+        Graph and snapshots to be uploaded should be placed like
+
+        Directory specified with upload_path arg
+          |
+          +-- graph
+          |
+          +-- waypoint_snapshots/
+          |     |
+          |     +-- waypont snapshot files
+          |
+          +-- edge_snapshots/
+                |
+                +-- edge snapshot files
+
+        Args:
+            upload_path (str): Path to the directory of the map.
+
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
+        """
+        try:
+            self._upload_graph_and_snapshots(upload_path)
+            return True, "Success"
+        except Exception as e:
+            return (
+                False,
+                f"Got an error while uploading a graph and snapshots to a robot: {e}",
+            )
+
+    def download_graph(self, download_path: str) -> typing.Tuple[bool, str]:
+        """Download current graph and snapshots in the robot to the specified directory.
+
+        Args:
+            download_path (str): Directory where graph and snapshots are downloaded from robot.
+
+        Returns: (bool, str) tuple indicating whether the command was successfully sent, and a message
+        """
+        try:
+            success, message = self._download_graph_and_snapshots(
+                download_path=download_path
+            )
+            return success, message
+        except Exception as e:
+            return (
+                False,
+                f"Got an error during downloading graph and snapshots from the robot: {e}",
+            )
+
     @try_claim
     def navigate_to(
         self,
@@ -2317,6 +2382,67 @@ class SpotWrapper:
                 "please localize the robot"
             )
 
+    def _write_bytes_while_download(self, filepath: str, data: bytes):
+        """Write data to a file.
+
+        Args:
+            filepath (str) : Path of file where data will be written.
+            data (bytes) : Bytes of data"""
+        directory = os.path.dirname(filepath)
+        os.makedirs(directory, exist_ok=True)
+        with open(filepath, "wb+") as f:
+            f.write(data)
+            f.close()
+
+    def _download_graph_and_snapshots(
+        self, download_path: str
+    ) -> typing.Tuple[bool, str]:
+        """Download the graph and snapshots from the robot.
+
+        Args:
+            download_path (str): Directory where graph and snapshots are downloaded from robot.
+
+        Returns:
+            success (bool): success flag
+            message (str): message"""
+        graph = self._graph_nav_client.download_graph()
+        if graph is None:
+            return False, "Failed to download the graph."
+        graph_bytes = graph.SerializeToString()
+        self._write_bytes_while_download(
+            os.path.join(download_path, "graph"), graph_bytes
+        )
+        # Download the waypoint and edge snapshots.
+        for waypoint in graph.waypoints:
+            try:
+                waypoint_snapshot = self._graph_nav_client.download_waypoint_snapshot(
+                    waypoint.snapshot_id
+                )
+            except Exception:
+                self.logger.warn(
+                    "Failed to download waypoint snapshot: %s", waypoint.snapshot_id
+                )
+                continue
+            self._write_bytes_while_download(
+                os.path.join(download_path, "waypoint_snapshots", waypoint.snapshot_id),
+                waypoint_snapshot.SerializeToString(),
+            )
+        for edge in graph.edges:
+            try:
+                edge_snapshot = self._graph_nav_client.download_edge_snapshot(
+                    edge.snapshot_id
+                )
+            except Exception:
+                self.logger.warn(
+                    "Failed to download edge snapshot: %s", edge.snapshot_id
+                )
+                continue
+            self._write_bytes_while_download(
+                os.path.join(download_path, "edge_snapshots", edge.snapshot_id),
+                edge_snapshot.SerializeToString(),
+            )
+        return True, "Success"
+
     @try_claim
     def _navigate_to(self, *args):
         """Navigate to a specific waypoint."""
@@ -2473,7 +2599,7 @@ class SpotWrapper:
                 self.toggle_power(should_power_on=False)
 
     def _clear_graph(self, *args):
-        """Clear the state of the map on the robot, removing all waypoints and edges."""
+        """Clear the state of the map on the robot, removing all waypoints and edges in the RAM of the robot."""
         result = self._graph_nav_client.clear_graph(lease=self._lease.lease_proto)
         self._init_current_graph_nav_state()
         return result

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -351,21 +351,28 @@ class AsyncPointCloudService(AsyncPeriodicQuery):
 
 
 class AsyncIdle(AsyncPeriodicQuery):
-    """Class to check if the robot is moving, and if not, command a stand with the set mobility parameters
-
-    Attributes:
-        client: The Client to a service on the robot
-        logger: Logger object
-        rate: Rate (Hz) to trigger the query
-        spot_wrapper: A handle to the wrapper library
+    """
+    Class to check if the robot is moving, and if not, command a stand with the set mobility parameters
     """
 
-    def __init__(self, client, logger, rate, spot_wrapper):
+    def __init__(
+        self,
+        client: RobotCommandClient,
+        logger: logging.Logger,
+        rate: float,
+        spot_wrapper,
+    ) -> None:
+        """
+        Attributes:
+            client: The Client to a service on the robot
+            logger: Logger object
+            rate: Rate (Hz) to trigger the query
+            spot_wrapper: A handle to the wrapper library
+        """
         super(AsyncIdle, self).__init__("idle", client, logger, period_sec=1.0 / rate)
+        self._spot_wrapper: SpotWrapper = spot_wrapper
 
-        self._spot_wrapper = spot_wrapper
-
-    def _start_query(self):
+    def _start_query(self) -> None:
         if self._spot_wrapper._last_stand_command != None:
             try:
                 response = self._client.robot_command_feedback(
@@ -374,24 +381,24 @@ class AsyncIdle(AsyncPeriodicQuery):
                 status = (
                     response.feedback.synchronized_feedback.mobility_command_feedback.stand_feedback.status
                 )
-                self._spot_wrapper._is_sitting = False
+                self._spot_wrapper.is_sitting = False
                 if status == basic_command_pb2.StandCommand.Feedback.STATUS_IS_STANDING:
-                    self._spot_wrapper._is_standing = True
+                    self._spot_wrapper.is_standing = True
                     self._spot_wrapper._last_stand_command = None
                 elif (
                     status == basic_command_pb2.StandCommand.Feedback.STATUS_IN_PROGRESS
                 ):
-                    self._spot_wrapper._is_standing = False
+                    self._spot_wrapper.is_standing = False
                 else:
                     self._logger.warning("Stand command in unknown state")
-                    self._spot_wrapper._is_standing = False
+                    self._spot_wrapper.is_standing = False
             except (ResponseError, RpcError) as e:
                 self._logger.error("Error when getting robot command feedback: %s", e)
                 self._spot_wrapper._last_stand_command = None
 
         if self._spot_wrapper._last_sit_command != None:
             try:
-                self._spot_wrapper._is_standing = False
+                self._spot_wrapper.is_standing = False
                 response = self._client.robot_command_feedback(
                     self._spot_wrapper._last_sit_command
                 )
@@ -399,10 +406,10 @@ class AsyncIdle(AsyncPeriodicQuery):
                     response.feedback.synchronized_feedback.mobility_command_feedback.sit_feedback.status
                     == basic_command_pb2.SitCommand.Feedback.STATUS_IS_SITTING
                 ):
-                    self._spot_wrapper._is_sitting = True
+                    self._spot_wrapper.is_sitting = True
                     self._spot_wrapper._last_sit_command = None
                 else:
-                    self._spot_wrapper._is_sitting = False
+                    self._spot_wrapper.is_sitting = False
             except (ResponseError, RpcError) as e:
                 self._logger.error("Error when getting robot command feedback: %s", e)
                 self._spot_wrapper._last_sit_command = None
@@ -434,7 +441,7 @@ class AsyncIdle(AsyncPeriodicQuery):
                         and not self._spot_wrapper._last_trajectory_command_precise
                     )
                 ):
-                    self._spot_wrapper._at_goal = True
+                    self._spot_wrapper.at_goal = True
                     # Clear the command once at the goal
                     self._spot_wrapper._last_trajectory_command = None
                     self._spot_wrapper._trajectory_status_unknown = False
@@ -448,7 +455,7 @@ class AsyncIdle(AsyncPeriodicQuery):
                     == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_NEAR_GOAL
                 ):
                     is_moving = True
-                    self._spot_wrapper._near_goal = True
+                    self._spot_wrapper.near_goal = True
                 elif (
                     status
                     == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_UNKNOWN
@@ -466,7 +473,7 @@ class AsyncIdle(AsyncPeriodicQuery):
                 self._logger.error("Error when getting robot command feedback: %s", e)
                 self._spot_wrapper._last_trajectory_command = None
 
-        self._spot_wrapper._is_moving = is_moving
+        self._spot_wrapper.is_moving = is_moving
 
         # We must check if any command currently has a non-None value for its id. If we don't do this, this stand
         # command can cause other commands to be interrupted before they get to start
@@ -555,6 +562,19 @@ def try_claim(func=None, *, power_on=False):
     return wrapper_try_claim
 
 
+@dataclass()
+class RobotState:
+    """
+    Dataclass which stores information about the robot's state. The values in it may be changed by methods
+    """
+
+    is_sitting: bool = True
+    is_standing: bool = False
+    is_moving: bool = False
+    at_goal: bool = False
+    near_goal: bool = False
+
+
 class SpotWrapper:
     """Generic wrapper class to encompass release 1.1.4 API features as well as maintaining leases automatically"""
 
@@ -615,11 +635,7 @@ class SpotWrapper:
         self._valid = True
 
         self._mobility_params = RobotCommandBuilder.mobility_params()
-        self._is_standing = False
-        self._is_sitting = True
-        self._is_moving = False
-        self._at_goal = False
-        self._near_goal = False
+        self._state = RobotState()
         self._trajectory_status_unknown = False
         self._last_robot_command_feedback = False
         self._last_stand_command = None
@@ -1068,25 +1084,45 @@ class SpotWrapper:
     @property
     def is_standing(self) -> bool:
         """Return boolean of standing state"""
-        return self._is_standing
+        return self._state.is_standing
+
+    @is_standing.setter
+    def is_standing(self, state: bool) -> None:
+        self._state.is_standing = state
 
     @property
     def is_sitting(self) -> bool:
         """Return boolean of standing state"""
-        return self._is_sitting
+        return self._state.is_sitting
+
+    @is_sitting.setter
+    def is_sitting(self, state: bool) -> None:
+        self._state.is_sitting = state
 
     @property
     def is_moving(self) -> bool:
         """Return boolean of walking state"""
-        return self._is_moving
+        return self._state.is_moving
+
+    @is_moving.setter
+    def is_moving(self, state: bool) -> None:
+        self._state.is_moving = state
 
     @property
     def near_goal(self) -> bool:
-        return self._near_goal
+        return self._state.near_goal
+
+    @near_goal.setter
+    def near_goal(self, state: bool) -> None:
+        self._state.near_goal = state
 
     @property
     def at_goal(self) -> bool:
-        return self._at_goal
+        return self._state.at_goal
+
+    @at_goal.setter
+    def at_goal(self, state: bool) -> None:
+        self._state.at_goal = state
 
     def is_estopped(self, timeout: typing.Optional[float] = None) -> bool:
         return self._robot.is_estopped(timeout=timeout)
@@ -1372,7 +1408,7 @@ class SpotWrapper:
         Returns:
             Tuple of bool success and a string message
         """
-        if self._is_sitting:
+        if self.is_sitting:
             response = self._robot_command(
                 RobotCommandBuilder.battery_change_pose_command(dir_hint)
             )
@@ -1502,8 +1538,8 @@ class SpotWrapper:
         if mobility_params is None:
             mobility_params = self._mobility_params
         self._trajectory_status_unknown = False
-        self._at_goal = False
-        self._near_goal = False
+        self.at_goal = False
+        self.near_goal = False
         self._last_trajectory_command_precise = precise_position
         self._logger.info("got command duration of {}".format(cmd_duration))
         end_time = time.time() + cmd_duration
@@ -1657,7 +1693,7 @@ class SpotWrapper:
                 f"Exception occured while Spot or its arm were trying to power on: {e}",
             )
 
-        if not self._is_standing:
+        if not self.is_standing:
             robot_command.blocking_stand(
                 command_client=self._robot_command_client, timeout_sec=10.0
             )


### PR DESCRIPTION
The ImageStreamWrapper does not allow you to save high quality images - it's supposed to be used for reference only as the images from webrtc have a lot of compression applied. This PR provides access to the MediaLog commands, which save images to disk on the cam and can then be read and saved locally once they are processed. This should give access to the highest quality images.

- [x] Test with an actual spot cam