### PR TITLE
[N/A] Remove typevar from spot_world_objects.py

### DIFF
--- a/spot_wrapper/spot_world_objects.py
+++ b/spot_wrapper/spot_world_objects.py
@@ -1,15 +1,11 @@
+from __future__ import annotations
 import logging
 import typing
 
-from bosdyn.api.world_object_pb2 import ListWorldObjectResponse
+from bosdyn.api.world_object_pb2 import ListWorldObjectResponse, WorldObjectType
 from bosdyn.client.async_tasks import AsyncPeriodicQuery
 from bosdyn.client.common import FutureWrapper
 from bosdyn.client.world_object import WorldObjectClient
-
-
-# This represents the WorldObjectType from bosdyn.api.world_object_pb2, which is an enum in the protobuf file.
-# In python, WorldObjectType is an EnumTypeWrapper object and thus cannot be used as a typehint
-WorldObjectType = typing.TypeVar("WorldObjectType")
 
 
 class AsyncWorldObjects(AsyncPeriodicQuery):


### PR DESCRIPTION
We added the typevar because using a protobuf enum type in a typing.Generic (e.g. typing.List) throws an exception during runtime: `TypeError: Parameters to generic types must be types. Got <google.protobuf.internal.enum_type_wrapper.EnumTypeWrapper object`.

You can remove the TypeVar if you use the annotations module from __future__ as explained [here](https://stackoverflow.com/questions/60342896/how-to-use-type-hinting-with-dictionaries-and-google-protobuf-enum). This simply postpones the evaluation of annotations.