### PR TITLE
Cam `set_ptz_position` can block until the target position is reached

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -5,6 +5,8 @@ import os.path
 import threading
 import typing
 import wave
+import time
+import math
 
 import bosdyn.client
 import cv2
@@ -491,7 +493,7 @@ class PTZWrapper:
         """
         return self.client.get_ptz_position(PtzDescription(name=ptz_name))
 
-    def set_ptz_position(self, ptz_name, pan, tilt, zoom):
+    def set_ptz_position(self, ptz_name, pan, tilt, zoom, blocking=False):
         """
         Set the position of the specified ptz
 
@@ -500,11 +502,28 @@ class PTZWrapper:
             pan: Set the pan to this value in degrees
             tilt: Set the tilt to this value in degrees
             zoom: Set the zoom to this zoom level
+            blocking: If true, block for 3 seconds or until the ptz is within 1 degree of the requested pan and tilt values, and
+                      0.5 zoom levels of the requested zoom level
         """
         pan, tilt, zoom = self._clamp_request_to_limits(ptz_name, pan, tilt, zoom)
         self.client.set_ptz_position(
             self._get_ptz_description(ptz_name), pan, tilt, zoom
         )
+        if blocking:
+            start_time = datetime.datetime.now()
+            current_position = self.client.get_ptz_position(
+                self._get_ptz_description(ptz_name)
+            )
+            while (
+                datetime.datetime.now() - start_time < datetime.timedelta(seconds=3)
+                or not math.isclose(current_position.pan, pan, abs_tol=1)
+                or not math.isclose(current_position.tilt, tilt, abs_tol=1)
+                or not math.isclose(current_position.zoom, zoom, abs_tol=0.5)
+            ):
+                current_position = self.client.get_ptz_position(
+                    self._get_ptz_description(ptz_name)
+                )
+                time.sleep(0.2)
 
     def get_ptz_velocity(self, ptz_name) -> PtzVelocity:
         """


### PR DESCRIPTION
This is useful when you need to capture images with the camera. Previously you would have to do the blocking in the caller which might be inconvenient.

Has been tested on a robot with cam.