### PR TITLE
[SW-341] Fix incorrect edge logging format in graphnav_util

### DIFF
--- a/spot_wrapper/graph_nav_util.py
+++ b/spot_wrapper/graph_nav_util.py
@@ -122,10 +122,7 @@ def update_waypoints_and_edges(graph, localization_id, logger):
             edges[edge.id.to_waypoint] = [edge.id.from_waypoint]
         logger.info(
             "(Edge) from waypoint id: %s and to waypoint id: %s"
-            % (
-                edge.id.from_waypoint,
-                edge.id.to_waypoint
-            )
+            % (edge.id.from_waypoint, edge.id.to_waypoint)
         )
 
     return name_to_id, edges

--- a/spot_wrapper/graph_nav_util.py
+++ b/spot_wrapper/graph_nav_util.py
@@ -121,10 +121,11 @@ def update_waypoints_and_edges(graph, localization_id, logger):
         else:
             edges[edge.id.to_waypoint] = [edge.id.from_waypoint]
         logger.info(
-            "(Edge) from waypoint id: ",
-            edge.id.from_waypoint,
-            " and to waypoint id: ",
-            edge.id.to_waypoint,
+            "(Edge) from waypoint id: %s and to waypoint id: %s"
+            % (
+                edge.id.from_waypoint,
+                edge.id.to_waypoint
+            )
         )
 
     return name_to_id, edges


### PR DESCRIPTION
Incorrect logging format in `update_waypoints_and_edges` would result in a crash when attempting to invoke the `list_graph` endpoint.