### PR TITLE
Add wrapper for Gripper Camera Param python client

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -13,14 +13,13 @@ import bosdyn.client
 import cv2
 import numpy as np
 from aiortc import RTCConfiguration
-from bosdyn.api import gripper_camera_param_pb2, image_pb2
+from bosdyn.api import image_pb2
 from bosdyn.api.data_chunk_pb2 import DataChunk
 from bosdyn.api.spot_cam import audio_pb2
 from bosdyn.api.spot_cam.camera_pb2 import Camera
 from bosdyn.api.spot_cam.logging_pb2 import Logpoint
 from bosdyn.api.spot_cam.ptz_pb2 import PtzDescription, PtzPosition, PtzVelocity
 from bosdyn.client import Robot, spot_cam
-from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.payload import PayloadClient
 from bosdyn.client.spot_cam.audio import AudioClient
 from bosdyn.client.spot_cam.compositor import CompositorClient
@@ -933,33 +932,8 @@ class ImageStreamWrapper:
         self.shutdown_flag.set()
 
 
-class GripperCameraParamWrapper:
-    """
-    Wrapper for gripper camera parameters
-    """
-
-    def __init__(self, robot: Robot, logger) -> None:
-        self._client: GripperCameraParamClient = robot.ensure_client(
-            GripperCameraParamClient.default_service_name
-        )
-        self._logger = logger
-
-    def set_params(
-        self, camera_param_request: gripper_camera_param_pb2.GripperCameraParamRequest
-    ) -> gripper_camera_param_pb2.GripperCameraParamResponse:
-        self._logger.info("Setting Gripper Camera Parameters")
-        return self._client.set_camera_params(camera_param_request)
-
-    def get_params(
-        self,
-        camera_get_param_request: gripper_camera_param_pb2.GripperCameraGetParamRequest,
-    ) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
-        self._logger.info("Getting Gripper Camera Parameters")
-        return self._client.get_camera_params(self, camera_get_param_request)
-
-
 class SpotCamWrapper:
-    def __init__(self, hostname, username, password, logger, has_arm=False):
+    def __init__(self, hostname, username, password, logger):
         self._hostname = hostname
         self._username = username
         self._password = password
@@ -998,9 +972,6 @@ class SpotCamWrapper:
         self.stream_quality = StreamQualityWrapper(self.robot, self._logger)
         self.media_log = MediaLogWrapper(self.robot, self._logger)
         self.ptz = PTZWrapper(self.robot, self._logger)
-
-        if has_arm:
-            self.gripper = GripperCameraParamWrapper(self.robot, self._logger)
 
         self._logger.info("Finished setting up spot cam wrapper components")
 

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -1,28 +1,26 @@
 import asyncio
 import datetime
 import enum
+import math
 import os.path
 import pathlib
-import shutil
 import threading
+import time
 import typing
 import wave
-import time
-import math
 
 import bosdyn.client
 import cv2
 import numpy as np
-from PIL import Image
 from aiortc import RTCConfiguration
-from bosdyn.api import image_pb2, gripper_camera_param_pb2
+from bosdyn.api import gripper_camera_param_pb2, image_pb2
 from bosdyn.api.data_chunk_pb2 import DataChunk
 from bosdyn.api.spot_cam import audio_pb2
 from bosdyn.api.spot_cam.camera_pb2 import Camera
 from bosdyn.api.spot_cam.logging_pb2 import Logpoint
-from bosdyn.api.spot_cam.ptz_pb2 import PtzDescription, PtzVelocity, PtzPosition
-from bosdyn.client import Robot
-from bosdyn.client import spot_cam
+from bosdyn.api.spot_cam.ptz_pb2 import PtzDescription, PtzPosition, PtzVelocity
+from bosdyn.client import Robot, spot_cam
+from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.payload import PayloadClient
 from bosdyn.client.spot_cam.audio import AudioClient
 from bosdyn.client.spot_cam.compositor import CompositorClient
@@ -32,7 +30,7 @@ from bosdyn.client.spot_cam.media_log import MediaLogClient
 from bosdyn.client.spot_cam.power import PowerClient
 from bosdyn.client.spot_cam.ptz import PtzClient
 from bosdyn.client.spot_cam.streamquality import StreamQualityClient
-from bosdyn.client.gripper_camera_param import GripperCameraParamClient
+from PIL import Image
 
 from spot_wrapper.cam_webrtc_client import WebRTCClient
 from spot_wrapper.wrapper import SpotWrapper
@@ -934,28 +932,31 @@ class ImageStreamWrapper:
 
         self.shutdown_flag.set()
 
+
 class GripperCameraParamWrapper:
     """
     Wrapper for gripper camera parameters
     """
 
-    def __init__(
-            self, 
-            robot: Robot, 
-            logger
-        ) -> None:
+    def __init__(self, robot: Robot, logger) -> None:
         self._client: GripperCameraParamClient = robot.ensure_client(
             GripperCameraParamClient.default_service_name
         )
         self._logger = logger
 
-    def set_params(self, camera_param_request: gripper_camera_param_pb2.GripperCameraParamRequest) -> gripper_camera_param_pb2.GripperCameraParamResponse: 
+    def set_params(
+        self, camera_param_request: gripper_camera_param_pb2.GripperCameraParamRequest
+    ) -> gripper_camera_param_pb2.GripperCameraParamResponse:
         self._logger.info("Setting Gripper Camera Parameters")
         return self._client.set_camera_params(camera_param_request)
 
-    def get_params(self, camera_get_param_request: gripper_camera_param_pb2.GripperCameraGetParamRequest) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
+    def get_params(
+        self,
+        camera_get_param_request: gripper_camera_param_pb2.GripperCameraGetParamRequest,
+    ) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
         self._logger.info("Getting Gripper Camera Parameters")
         return self._client.get_camera_params(self, camera_get_param_request)
+
 
 class SpotCamWrapper:
     def __init__(self, hostname, username, password, logger, has_arm=False):

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -453,11 +453,12 @@ class SpotImages:
     ) -> gripper_camera_param_pb2.GripperCameraParamResponse:
         if not self._robot.has_arm:
             raise Exception("Gripper camera is not available")
-        self._logger.info("Setting Gripper Camera Parameters")
-        response = self._gripper_cam_param_client.set_camera_params(
-            camera_param_request
-        )
-        return response
+        else:
+            self._logger.info("Setting Gripper Camera Parameters")
+            response = self._gripper_cam_param_client.set_camera_params(
+                camera_param_request
+            )
+            return response
 
     def get_gripper_camera_params(
         self,
@@ -465,8 +466,9 @@ class SpotImages:
     ) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
         if not self._robot.has_arm:
             raise Exception("Gripper camera is not available")
-        self._logger.info("Getting Gripper Camera Parameters")
-        response = self._gripper_cam_param_client.get_camera_params(
-            camera_get_param_request
-        )
-        return response
+        else:
+            self._logger.info("Getting Gripper Camera Parameters")
+            response = self._gripper_cam_param_client.get_camera_params(
+                camera_get_param_request
+            )
+            return response

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -460,5 +460,5 @@ class SpotImages:
     ) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
         self._logger.info("Getting Gripper Camera Parameters")
         return self._gripper_cam_param_client.get_camera_params(
-            self, camera_get_param_request
+            camera_get_param_request
         )

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -3,11 +3,12 @@ import typing
 from collections import namedtuple
 from dataclasses import dataclass
 
-from bosdyn.api import image_pb2
+from bosdyn.api import gripper_camera_param_pb2, image_pb2
+from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.image import (
     ImageClient,
-    build_image_request,
     UnsupportedPixelFormatRequestedError,
+    build_image_request,
 )
 from bosdyn.client.robot import Robot
 
@@ -153,6 +154,9 @@ class SpotImages:
         self._rgb_cameras = rgb_cameras
         self._image_client = image_client
         self._image_quality = image_quality
+        self._gripper_cam_param_client = robot.ensure_client(
+            GripperCameraParamClient.default_service_name
+        )
 
         ############################################
         self._camera_image_requests = []
@@ -443,3 +447,18 @@ class SpotImages:
                 )
             )
         return result
+
+    def set_gripper_camera_params(
+        self, camera_param_request: gripper_camera_param_pb2.GripperCameraParamRequest
+    ) -> gripper_camera_param_pb2.GripperCameraParamResponse:
+        self._logger.info("Setting Gripper Camera Parameters")
+        return self._gripper_cam_param_client.set_camera_params(camera_param_request)
+
+    def get_gripper_camera_params(
+        self,
+        camera_get_param_request: gripper_camera_param_pb2.GripperCameraGetParamRequest,
+    ) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
+        self._logger.info("Getting Gripper Camera Parameters")
+        return self._gripper_cam_param_client.get_camera_params(
+            self, camera_get_param_request
+        )

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -138,6 +138,7 @@ class SpotImages:
         robot: Robot,
         logger: logging.Logger,
         image_client: ImageClient,
+        gripper_cam_param_client: GripperCameraParamClient,
         rgb_cameras: bool = True,
         image_quality: ImageQualityConfig = ImageQualityConfig(),
     ) -> None:
@@ -154,9 +155,7 @@ class SpotImages:
         self._rgb_cameras = rgb_cameras
         self._image_client = image_client
         self._image_quality = image_quality
-        self._gripper_cam_param_client = self._robot.ensure_client(
-            GripperCameraParamClient.default_service_name
-        )
+        self._gripper_cam_param_client = gripper_cam_param_client
 
         ############################################
         self._camera_image_requests = []

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -3,7 +3,7 @@ import typing
 from collections import namedtuple
 from dataclasses import dataclass
 
-from bosdyn.api import gripper_camera_param_pb2, header_pb2, image_pb2
+from bosdyn.api import gripper_camera_param_pb2, image_pb2
 from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.image import (
     ImageClient,
@@ -454,12 +454,6 @@ class SpotImages:
         response = self._gripper_cam_param_client.set_camera_params(
             camera_param_request
         )
-        if (
-            response.header.error
-            and response.header.error.code != header_pb2.CommonError.CODE_OK
-        ):
-            print("Got an error:")
-            print(response.header.error)
         return response
 
     def get_gripper_camera_params(
@@ -470,10 +464,4 @@ class SpotImages:
         response = self._gripper_cam_param_client.get_camera_params(
             camera_get_param_request
         )
-        if (
-            response.header.error
-            and response.header.error.code != header_pb2.CommonError.CODE_OK
-        ):
-            print("Got an error:")
-            print(response.header.error)
         return response

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -138,7 +138,7 @@ class SpotImages:
         robot: Robot,
         logger: logging.Logger,
         image_client: ImageClient,
-        gripper_cam_param_client: GripperCameraParamClient,
+        gripper_cam_param_client: GripperCameraParamClient = None,
         rgb_cameras: bool = True,
         image_quality: ImageQualityConfig = ImageQualityConfig(),
     ) -> None:
@@ -148,6 +148,7 @@ class SpotImages:
             robot: Robot object this image module is associated with
             logger: Logger to use
             image_client: Image client to use to retrieve images
+            gripper_cam_param_client: Gripper Camera Parameter client used to adjust gripper camera settings
             rgb_cameras: If true, the robot model has RGB cameras as opposed to greyscale ones.
         """
         self._robot = robot
@@ -450,6 +451,8 @@ class SpotImages:
     def set_gripper_camera_params(
         self, camera_param_request: gripper_camera_param_pb2.GripperCameraParamRequest
     ) -> gripper_camera_param_pb2.GripperCameraParamResponse:
+        if not self._robot.has_arm:
+            raise Exception("Gripper camera is not available")
         self._logger.info("Setting Gripper Camera Parameters")
         response = self._gripper_cam_param_client.set_camera_params(
             camera_param_request
@@ -460,6 +463,8 @@ class SpotImages:
         self,
         camera_get_param_request: gripper_camera_param_pb2.GripperCameraGetParamRequest,
     ) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
+        if not self._robot.has_arm:
+            raise Exception("Gripper camera is not available")
         self._logger.info("Getting Gripper Camera Parameters")
         response = self._gripper_cam_param_client.get_camera_params(
             camera_get_param_request

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -3,7 +3,7 @@ import typing
 from collections import namedtuple
 from dataclasses import dataclass
 
-from bosdyn.api import gripper_camera_param_pb2, image_pb2
+from bosdyn.api import gripper_camera_param_pb2, header_pb2, image_pb2
 from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.image import (
     ImageClient,
@@ -452,13 +452,29 @@ class SpotImages:
         self, camera_param_request: gripper_camera_param_pb2.GripperCameraParamRequest
     ) -> gripper_camera_param_pb2.GripperCameraParamResponse:
         self._logger.info("Setting Gripper Camera Parameters")
-        return self._gripper_cam_param_client.set_camera_params(camera_param_request)
+        response = self._gripper_cam_param_client.set_camera_params(
+            camera_param_request
+        )
+        if (
+            response.header.error
+            and response.header.error.code != header_pb2.CommonError.CODE_OK
+        ):
+            print("Got an error:")
+            print(response.header.error)
+        return response
 
     def get_gripper_camera_params(
         self,
         camera_get_param_request: gripper_camera_param_pb2.GripperCameraGetParamRequest,
     ) -> gripper_camera_param_pb2.GripperCameraGetParamResponse:
         self._logger.info("Getting Gripper Camera Parameters")
-        return self._gripper_cam_param_client.get_camera_params(
+        response = self._gripper_cam_param_client.get_camera_params(
             camera_get_param_request
         )
+        if (
+            response.header.error
+            and response.header.error.code != header_pb2.CommonError.CODE_OK
+        ):
+            print("Got an error:")
+            print(response.header.error)
+        return response

--- a/spot_wrapper/spot_images.py
+++ b/spot_wrapper/spot_images.py
@@ -154,7 +154,7 @@ class SpotImages:
         self._rgb_cameras = rgb_cameras
         self._image_client = image_client
         self._image_quality = image_quality
-        self._gripper_cam_param_client = robot.ensure_client(
+        self._gripper_cam_param_client = self._robot.ensure_client(
             GripperCameraParamClient.default_service_name
         )
 

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -13,7 +13,13 @@ from bosdyn.api import (
     world_object_pb2,
 )
 from bosdyn.api.spot import robot_command_pb2 as spot_command_pb2
-from bosdyn.client import ResponseError, RpcError, create_standard_sdk, frame_helpers, math_helpers
+from bosdyn.client import (
+    ResponseError,
+    RpcError,
+    create_standard_sdk,
+    frame_helpers,
+    math_helpers,
+)
 from bosdyn.client.async_tasks import AsyncPeriodicQuery, AsyncTasks
 from bosdyn.client.docking import DockingClient
 from bosdyn.client.estop import (
@@ -606,7 +612,11 @@ class SpotWrapper:
             self._spot_arm = None
 
         self._spot_images = SpotImages(
-            self._robot, self._logger, self._image_client, self._gripper_cam_param_client, self._rgb_cameras
+            self._robot,
+            self._logger,
+            self._image_client,
+            self._gripper_cam_param_client,
+            self._rgb_cameras,
         )
 
         self._spot_docking = SpotDocking(

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -477,9 +477,6 @@ class SpotWrapper:
                 self._graph_nav_client = self._robot.ensure_client(
                     GraphNavClient.default_service_name
                 )
-                self._gripper_cam_param_client = self._robot.ensure_client(
-                    GripperCameraParamClient.default_service_name
-                )
                 self._map_processing_client = self._robot.ensure_client(
                     MapProcessingServiceClient.default_service_name
                 )
@@ -505,7 +502,10 @@ class SpotWrapper:
                 self._license_client = self._robot.ensure_client(
                     LicenseClient.default_service_name
                 )
-
+                if self._robot.has_arm():
+                    self._gripper_cam_param_client = self._robot.ensure_client(
+                        GripperCameraParamClient.default_service_name
+                    )
                 if HAVE_CHOREOGRAPHY:
                     if self._license_client.get_feature_enabled(
                         [ChoreographyClient.license_name]
@@ -608,16 +608,23 @@ class SpotWrapper:
                 MAX_COMMAND_DURATION,
                 self._claim_decorator,
             )
+
+            self._spot_images = SpotImages(
+                self._robot,
+                self._logger,
+                self._image_client,
+                self._rgb_cameras,
+            )
         else:
             self._spot_arm = None
 
-        self._spot_images = SpotImages(
-            self._robot,
-            self._logger,
-            self._image_client,
-            self._gripper_cam_param_client,
-            self._rgb_cameras,
-        )
+            self._spot_images = SpotImages(
+                self._robot,
+                self._logger,
+                self._image_client,
+                self._gripper_cam_param_client,
+                self._rgb_cameras,
+            )
 
         self._spot_docking = SpotDocking(
             self._robot,

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1,31 +1,19 @@
-from dataclasses import dataclass
-import functools
 import logging
-import math
-import os
 import time
 import traceback
 import typing
 
 import bosdyn.client.auth
-from bosdyn.api import arm_command_pb2
-from bosdyn.api import geometry_pb2
-from bosdyn.api import lease_pb2
-from bosdyn.api import point_cloud_pb2
-from bosdyn.api import manipulation_api_pb2
-from bosdyn.api import robot_command_pb2
+from bosdyn.api import (
+    lease_pb2,
+    manipulation_api_pb2,
+    point_cloud_pb2,
+    robot_command_pb2,
+    robot_state_pb2,
+    world_object_pb2,
+)
 from bosdyn.api.spot import robot_command_pb2 as spot_command_pb2
-from bosdyn.api import robot_state_pb2
-from bosdyn.api import synchronized_command_pb2
-from bosdyn.api import trajectory_pb2
-from bosdyn.api import world_object_pb2
-from bosdyn.api import point_cloud_pb2
-from bosdyn.api.graph_nav import graph_nav_pb2
-from bosdyn.api.graph_nav import map_pb2
-from bosdyn.api.graph_nav import nav_pb2
-from bosdyn.client import frame_helpers
-from bosdyn.client import math_helpers
-from bosdyn.client import robot_command
+from bosdyn.client import ResponseError, RpcError, create_standard_sdk, frame_helpers, math_helpers
 from bosdyn.client.async_tasks import AsyncPeriodicQuery, AsyncTasks
 from bosdyn.client.docking import DockingClient
 from bosdyn.client.estop import (
@@ -33,29 +21,27 @@ from bosdyn.client.estop import (
     EstopEndpoint,
     EstopKeepAlive,
 )
-from bosdyn.client.frame_helpers import get_odom_tform_body
 from bosdyn.client.graph_nav import GraphNavClient
+from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.image import ImageClient
 from bosdyn.client.lease import LeaseClient, LeaseKeepAlive
+from bosdyn.client.license import LicenseClient
 from bosdyn.client.manipulation_api_client import ManipulationApiClient
 from bosdyn.client.map_processing import MapProcessingServiceClient
-from bosdyn.client.point_cloud import build_pc_request
 from bosdyn.client.payload_registration import PayloadNotAuthorizedError
-from bosdyn.client.point_cloud import PointCloudClient, build_pc_request
-from bosdyn.client.power import safe_power_off, PowerClient, power_on
-from bosdyn.client.robot import UnregisteredServiceError, Robot
-from bosdyn.client.robot_command import RobotCommandClient, RobotCommandBuilder
+from bosdyn.client.power import PowerClient, power_on, safe_power_off
+from bosdyn.client.robot import Robot, UnregisteredServiceError
+from bosdyn.client.robot_command import RobotCommandBuilder, RobotCommandClient
 from bosdyn.client.robot_state import RobotStateClient
 from bosdyn.client.spot_check import SpotCheckClient
 from bosdyn.client.time_sync import TimeSyncEndpoint
 from bosdyn.client.world_object import WorldObjectClient
-from bosdyn.client.license import LicenseClient
-from bosdyn.client import ResponseError, RpcError, create_standard_sdk
 
 try:
     from bosdyn.choreography.client.choreography import (
         ChoreographyClient,
     )
+
     from .spot_dance import SpotDance
 
     HAVE_CHOREOGRAPHY = True
@@ -63,8 +49,6 @@ except ModuleNotFoundError:
     HAVE_CHOREOGRAPHY = False
 
 from bosdyn.geometry import EulerZXY
-from bosdyn.util import seconds_to_duration
-from google.protobuf.duration_pb2 import Duration
 
 SPOT_CLIENT_NAME = "ros_spot"
 MAX_COMMAND_DURATION = 1e5
@@ -80,8 +64,7 @@ from .spot_eap import SpotEAP
 from .spot_graph_nav import SpotGraphNav
 from .spot_images import SpotImages
 from .spot_world_objects import SpotWorldObjects
-
-from .wrapper_helpers import RobotCommandData, RobotState, ClaimAndPowerDecorator
+from .wrapper_helpers import ClaimAndPowerDecorator, RobotCommandData, RobotState
 
 
 def robotToLocalTime(timestamp: Timestamp, robot: Robot) -> Timestamp:
@@ -488,6 +471,9 @@ class SpotWrapper:
                 self._graph_nav_client = self._robot.ensure_client(
                     GraphNavClient.default_service_name
                 )
+                self._gripper_cam_param_client = self._robot.ensure_client(
+                    GripperCameraParamClient.default_service_name
+                )
                 self._map_processing_client = self._robot.ensure_client(
                     MapProcessingServiceClient.default_service_name
                 )
@@ -620,7 +606,7 @@ class SpotWrapper:
             self._spot_arm = None
 
         self._spot_images = SpotImages(
-            self._robot, self._logger, self._image_client, self._rgb_cameras
+            self._robot, self._logger, self._image_client, self._gripper_cam_param_client, self._rgb_cameras
         )
 
         self._spot_docking = SpotDocking(

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -506,6 +506,9 @@ class SpotWrapper:
                     self._gripper_cam_param_client = self._robot.ensure_client(
                         GripperCameraParamClient.default_service_name
                     )
+                else:
+                    self._gripper_cam_param_client = None
+
                 if HAVE_CHOREOGRAPHY:
                     if self._license_client.get_feature_enabled(
                         [ChoreographyClient.license_name]
@@ -608,23 +611,16 @@ class SpotWrapper:
                 MAX_COMMAND_DURATION,
                 self._claim_decorator,
             )
-
-            self._spot_images = SpotImages(
-                self._robot,
-                self._logger,
-                self._image_client,
-                self._gripper_cam_param_client,
-                self._rgb_cameras,
-            )
         else:
             self._spot_arm = None
 
-            self._spot_images = SpotImages(
-                self._robot,
-                self._logger,
-                self._image_client,
-                self._rgb_cameras,
-            )
+        self._spot_images = SpotImages(
+            self._robot,
+            self._logger,
+            self._image_client,
+            self._gripper_cam_param_client,
+            self._rgb_cameras,
+        )
 
         self._spot_docking = SpotDocking(
             self._robot,

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -613,6 +613,7 @@ class SpotWrapper:
                 self._robot,
                 self._logger,
                 self._image_client,
+                self._gripper_cam_param_client,
                 self._rgb_cameras,
             )
         else:
@@ -622,7 +623,6 @@ class SpotWrapper:
                 self._robot,
                 self._logger,
                 self._image_client,
-                self._gripper_cam_param_client,
                 self._rgb_cameras,
             )
 


### PR DESCRIPTION
This PR adds a wrapper for the Gripper Camera Param python client to `cam_wrapper.py`. This is a dependency for [this PR to spot_ros2](https://github.com/bdaiinstitute/spot_ros2/pull/138) that adds ros2 services for getting and setting gripper camera params.