### PR TITLE
[N/A]Add Image to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ protobuf==4.22.1
 setuptools==45.2.0
 pytest==7.3.1
 aiortc==1.5.0
+image==1.5.33


### PR DESCRIPTION
As part of an effort to add a CI Job to `spot_ros2` to run tests, I discovered that the `Image` library was needed but not installed by the CI runner, leading to a failure. 