### PR TITLE
Updated requirements to use ROS2 messages 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-bosdyn-core==3.2.3
-bosdyn_choreography_client==3.2.3
-bosdyn_choreography_protos==3.2.3
-bosdyn-client==3.2.3
-bosdyn-mission==3.2.3
-bosdyn-api==3.2.3
+bosdyn-core==3.3.2
+bosdyn_choreography_client==3.3.2
+bosdyn_choreography_protos==3.3.2
+bosdyn-client==3.3.2
+bosdyn-mission==3.3.2
+bosdyn-api==3.3.2
 protobuf==4.22.1
 setuptools==45.2.0
 pytest==7.3.1


### PR DESCRIPTION
In this PR I'm updating the requirements for the `spot_ros2` installation script to download and install the debian packages containing the ROS2 messages for Post SDK 3.3.2.

`spot_wrapper` is a submodule of `spot_ros2` package and this PR must be approved before the following:

https://github.com/bdaiinstitute/spot_ros2/pull/177

