### PR TITLE
claim estop on power on only if isn't already acquired

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1283,8 +1283,8 @@ class SpotWrapper:
         """
         # Don't bother trying to power on if we are already powered on
         if not self.check_is_powered_on():
-            # If we are requested to start the estop, we have to acquire it when powering on.
-            if self._start_estop:
+            # If we are requested to start the estop, we have to acquire it when powering on. Ignore if estop is already acquired.
+            if self._start_estop and self._estop_keepalive is None:
                 self.resetEStop()
             try:
                 self._logger.info("Powering on")


### PR DESCRIPTION
For spot_driver with estop, if power_off is called, and power_on is called, driver crashes as an error is thrown as it tries to reset estop. Prevent this case.