### PR TITLE
Add `spot_wrapper.testing` machinery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.orig
 build
 spot_wrapper.egg-info
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ setuptools==59.6.0
 pytest==7.3.1
 aiortc==1.5.0
 image==1.5.33
+inflection==0.5.1
+grpcio==1.59.3

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ setup(
     version="1.0.0",
     description="Wrapper for Boston Dynamics Spot SDK",
     packages=["spot_wrapper"],
-    install_requires=["bosdyn-client", "bosdyn-api", "bosdyn-mission", "bosdyn-core"],
+    install_requires=["bosdyn-client", "bosdyn-api", "bosdyn-mission", "bosdyn-core", "grpcio", "inflection", "pytest"],
 )

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -933,7 +933,7 @@ class ImageStreamWrapper:
 
 
 class SpotCamWrapper:
-    def __init__(self, hostname, username, password, logger):
+    def __init__(self, hostname, username, password, logger, port: typing.Optional[int] = None):
         self._hostname = hostname
         self._username = username
         self._password = password
@@ -944,6 +944,8 @@ class SpotCamWrapper:
         spot_cam.register_all_service_clients(self.sdk)
 
         self.robot = self.sdk.create_robot(self._hostname)
+        if port is not None:
+            self.robot.update_secure_channel_port(port)
         SpotWrapper.authenticate(
             self.robot, self._username, self._password, self._logger
         )

--- a/spot_wrapper/spot_dance.py
+++ b/spot_wrapper/spot_dance.py
@@ -1,3 +1,4 @@
+import logging
 import time
 import tempfile
 import os
@@ -27,7 +28,6 @@ from bosdyn.api.spot.choreography_sequence_pb2 import (
     UploadChoreographyResponse,
 )
 from google.protobuf import text_format
-from rclpy.impl.rcutils_logger import RcutilsLogger
 from typing import Tuple, List, Union
 
 
@@ -36,7 +36,7 @@ class SpotDance:
         self,
         robot: Robot,
         choreography_client: ChoreographyClient,
-        logger: RcutilsLogger,
+        logger: logging.Logger
     ):
         self._robot = robot
         self._choreography_client = choreography_client

--- a/spot_wrapper/testing/__init__.py
+++ b/spot_wrapper/testing/__init__.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+"""
+This subpackage provides `pytest` compatible machinery to test Spot SDK use.
+
+At its core, this machinery is nothing but mocks and fixtures: mocks of Spot gRPC
+services, and fixtures serving those mocks over the wire.
+
+Mocks are basically gRPC servicer subclasses. Several mock classes, targeting the
+many services that Spot robots expose and designed for aggregation via multiple
+inheritance, are available under `spot_wrapper.testing.mocks`. In combination,
+these classes afford centralized, cohesive mock implementations.
+
+.. note::
+
+   To mock the Spot SDK at the gRPC interface level adds complexity to mock
+   implementations, low-level as this interface is. In exchange, these mocks
+   have complete control over a well-defined interface that spans the entire
+   feature set.
+
+Fixtures are `pytest.fixture`s built around mock classes. Decorating a mock class with
+the `spot_wrapper.testing.fixture` function turns it into a fixture. When requested by
+a test, a fixture will start a gRPC server to host mocked services for as long as
+it remains in scope. This gRPC server will listen at a unique address, which is made
+available to the test.
+
+.. code-block:: python
+
+   from spot_wrapper.wrapper import SpotWrapper
+
+   import spot_wrapper.testing
+   from spot_wrapper.testing.mocks import MockSpot
+
+   @spot_wrapper.testing.fixture
+   class fake_spot(MockSpot):
+       pass
+
+   def test_wrapper(fake_spot):
+       wrapper = SpotWrapper(
+           username="spot",
+           password="spot",
+           hostname=fake_spot.address,
+           port=fake_spot.port,
+           robot_name=simple_spot.api.name,
+           logger=logging.getLogger("spot"),
+       )
+       assert wrapper.valid
+
+
+No built-in fixtures are provided, as these are always user-defined.
+`spot_wrapper.testing.mocks.MockSpot` implements enough Spot gRPC
+services for both Spot SDK and `SpotWrapper` to initialize, but enough
+does not mean all. A mock need not implement all Spot gRPC services, as
+long as either non-implemented gRPC services are never called or the mock
+is autospec'd. Autospec'd `spot_wrapper.testing.mocks.BaseMockSpot`
+subclasses, and `spot_wrapper.testing.mocks.MockSpot` is one such class,
+will define _deferred method handlers_ for non-implemented services.
+A deferred method handler is a callable that allows resolving gRPC
+service calls in advance, specifying their future outcome, and serving
+them as they come in the main thread. In a way, these handlers are the
+`unittest.mock.Mock` equivalents for gRPC services.
+
+.. code-block:: python
+
+   from spot_wrapper.wrapper import SpotWrapper
+
+   import spot_wrapper.testing
+   from spot_wrapper.testing.mocks import MockSpot
+
+   from bosdyn.api.robot_command_pb2 import RobotCommandResponse
+
+   @spot_wrapper.testing.fixture
+   class fake_spot(MockSpot):
+       pass
+
+   def test_wrapper(fake_spot):
+       wrapper = SpotWrapper(
+           username="spot",
+           password="spot",
+           hostname=fake_spot.address,
+           port=fake_spot.port,
+           robot_name=simple_spot.api.name,
+           logger=logging.getLogger("spot"),
+       )
+       assert wrapper.valid
+
+       response = RobotCommandResponse()
+       response.status = RobotCommandResponse.Status.STATUS_OK
+       fake_spot.api.RobotCommand.future.returns(response)
+       ok, message = wrapper.sit()
+       assert ok, message
+"""
+
+from spot_wrapper.testing.fixtures import fixture
+
+__all__ = ["fixture"]

--- a/spot_wrapper/testing/fixtures.py
+++ b/spot_wrapper/testing/fixtures.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import concurrent.futures
+import dataclasses
+import functools
+import inspect
+import typing
+
+import grpc
+import pytest
+
+from spot_wrapper.testing.mocks import BaseMockSpot
+
+
+@dataclasses.dataclass
+class SpotFixture:
+    """
+    A fixture that emulates a Spot robot.
+
+    Attributes:
+        address: address for the emulated Spot robot gRPC server.
+        port: port for the emulated Spot robot gRPC server.
+        api: mocked API for the emulated Spot robot.
+    """
+
+    address: str
+    port: int
+    api: BaseMockSpot
+
+
+def fixture(
+    cls: typing.Optional[typing.Type[BaseMockSpot]] = None,
+    *,
+    address: str = "127.0.0.1",
+    max_workers: int = 10,
+    **kwargs: typing.Any,
+) -> typing.Callable:
+    """
+    A `pytest.fixture` of a mocked Spot robot.
+
+    This function takes a Spot mock class by decorating it. Spot mock classes may
+    request parameters like any `pytest.fixture` would do by specifying them in their
+    __init__ methods.
+
+    Mocked Spot robots are served through insecure gRPC channels. To enable Spot SDK
+    use, this fixture patches gRPC secure channel creation, forcing them to be insecure.
+
+    Args:
+        address: address for underlying gRPC server.
+        port: port number for underlying gRPC server.
+        max_workers: maximum number of threads to use for gRPC call servicing.
+
+    Other keyword arguments are forwarded to `pytest.fixture`.
+    """
+
+    def decorator(cls: typing.Type[BaseMockSpot]) -> typing.Callable:
+        def fixturefunc(monkeypatch, **kwargs) -> typing.Iterator[SpotFixture]:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=max_workers
+            ) as thread_pool:
+                server = grpc.server(thread_pool)
+                port = server.add_insecure_port(f"{address}:0")
+                with cls(**kwargs) as mock:
+                    mock.add_to(server)
+                    server.start()
+                    try:
+                        with monkeypatch.context() as m:
+
+                            def mock_secure_channel(target, _, *args, **kwargs):
+                                return grpc.insecure_channel(target, *args, **kwargs)
+
+                            m.setattr(grpc, "secure_channel", mock_secure_channel)
+                            yield SpotFixture(address=address, port=port, api=mock)
+                    finally:
+                        server.stop(grace=None)
+
+        functools.update_wrapper(fixturefunc, cls)
+        sig = inspect.signature(fixturefunc)
+        if "monkeypatch" not in sig.parameters:
+            sig = sig.replace(
+                parameters=(
+                    inspect.Parameter(
+                        "monkeypatch", inspect.Parameter.POSITIONAL_OR_KEYWORD
+                    ),
+                    *sig.parameters.values(),
+                )
+            )
+            fixturefunc.__signature__ = sig  # noqa
+
+        return pytest.fixture(fixturefunc, **kwargs)
+
+    if cls is None:
+        return decorator
+    return decorator(cls)

--- a/spot_wrapper/testing/grpc.py
+++ b/spot_wrapper/testing/grpc.py
@@ -1,0 +1,452 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import inspect
+import logging
+import os
+import queue
+import sys
+import threading
+import typing
+
+import grpc
+
+from spot_wrapper.testing.helpers import GeneralizedDecorator
+
+
+def implemented(function: typing.Callable) -> bool:
+    """
+    Checks if a given `function` is implemented or not.
+
+    To do so, its source code is inspected looking for NotImplementedError exception use.
+    """
+    if inspect.ismethod(function):
+        function = function.__func__
+    if not hasattr(function, "__code__"):
+        raise ValueError(f"no code associated to {function}")
+    return "NotImplementedError" not in function.__code__.co_names
+
+
+class GenericRpcHandlerAccumulator:
+    """A helper class to use in place of a `grpc.Server` to inspect handlers."""
+
+    def __init__(self) -> None:
+        self.handlers: typing.List[grpc.GenericRpcHandler] = []
+
+    @property
+    def service_types(self) -> typing.Iterable[str]:
+        """Yields all service types known to the accumulator."""
+        for handler in self.handlers:
+            if hasattr(handler, "service_name"):
+                yield handler.service_name()
+
+    @property
+    def method_handlers(
+        self,
+    ) -> typing.Iterable[typing.Tuple[str, grpc.RpcMethodHandler]]:
+        """Yields all RPC method handlers known to the accumulator."""
+        for handler in self.handlers:
+            if hasattr(handler, "_method_handlers"):
+                yield from handler._method_handlers.items()
+
+    def add_generic_rpc_handlers(
+        self, handlers: typing.Iterable[grpc.GenericRpcHandler]
+    ) -> None:
+        """Implements `grpc.Server.add_generic_rcp_handlers`."""
+        self.handlers.extend(handlers)
+
+
+def collect_servicer_add_functions(
+    servicer_class: typing.Any,
+) -> typing.Iterable[typing.Callable]:
+    """Yields all generated ``add_*_to_server`` functions associated with the given `servicer_class`."""
+    for cls in servicer_class.__mro__:
+        module = sys.modules[cls.__module__]
+        servicer_add_function_name = f"add_{cls.__name__}_to_server"
+        servicer_add = getattr(module, servicer_add_function_name, None)
+        if callable(servicer_add):
+            yield servicer_add
+
+
+def collect_method_handlers(
+    servicer: typing.Any,
+) -> typing.Iterable[typing.Tuple[str, grpc.RpcMethodHandler]]:
+    """Yields all RPC method handlers for the given `servicer`."""
+    accumulator = GenericRpcHandlerAccumulator()
+    for add in collect_servicer_add_functions(servicer.__class__):
+        add(servicer, accumulator)
+    yield from accumulator.method_handlers
+
+
+def collect_service_types(servicer: typing.Any) -> typing.Iterable[str]:
+    """Yields all service type names for the given `servicer`."""
+    accumulator = GenericRpcHandlerAccumulator()
+    for add in collect_servicer_add_functions(servicer.__class__):
+        add(servicer, accumulator)
+    yield from accumulator.service_types
+
+
+class AutoServicer(object):
+    """
+    A mocking gRPC servicer to ease testing.
+
+    Attributes:
+        autospec: if true, deferred handlers will be used in place for every
+        non-implemented method handler.
+        autotrack: if true, tracking handlers will decorate every method handler.
+    """
+
+    autospec = False
+    autotrack = False
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.needs_shutdown: typing.List[typing.Any] = []
+        for name, handler in collect_method_handlers(self):
+            if handler.response_streaming:
+                if handler.request_streaming:
+                    unqualified_name = handler.stream_stream.__name__
+                    underlying_callable = handler.stream_stream
+                    if self.autospec and not implemented(underlying_callable):
+                        underlying_callable = DeferredStreamRpcHandler(
+                            underlying_callable
+                        )
+                        self.needs_shutdown.append(underlying_callable)
+                    if self.autotrack:
+                        underlying_callable = TrackingStreamStreamRpcHandler(
+                            underlying_callable
+                        )
+                    if underlying_callable is not handler.stream_stream:
+                        setattr(self, unqualified_name, underlying_callable)
+                else:
+                    unqualified_name = handler.unary_stream.__name__
+                    underlying_callable = handler.unary_stream
+                    if self.autospec and not implemented(underlying_callable):
+                        underlying_callable = DeferredStreamRpcHandler(
+                            underlying_callable
+                        )
+                        self.needs_shutdown.append(underlying_callable)
+                    if self.autotrack:
+                        underlying_callable = TrackingUnaryStreamRpcHandler(
+                            underlying_callable
+                        )
+                    if underlying_callable is not handler.unary_stream:
+                        setattr(self, unqualified_name, underlying_callable)
+            else:
+                if handler.request_streaming:
+                    unqualified_name = handler.stream_unary.__name__
+                    underlying_callable = handler.stream_unary
+                    if self.autospec and not implemented(underlying_callable):
+                        underlying_callable = DeferredUnaryRpcHandler(
+                            underlying_callable
+                        )
+                        self.needs_shutdown.append(underlying_callable)
+                    if self.autotrack:
+                        underlying_callable = TrackingStreamUnaryRpcHandler(
+                            underlying_callable
+                        )
+                    if underlying_callable is not handler.stream_unary:
+                        setattr(self, unqualified_name, underlying_callable)
+                else:
+                    unqualified_name = handler.unary_unary.__name__
+                    underlying_callable = handler.unary_unary
+                    if self.autospec and not implemented(underlying_callable):
+                        underlying_callable = DeferredUnaryRpcHandler(
+                            underlying_callable
+                        )
+                        self.needs_shutdown.append(underlying_callable)
+                    if self.autotrack:
+                        underlying_callable = TrackingUnaryUnaryRpcHandler(
+                            underlying_callable
+                        )
+                    if underlying_callable is not handler.unary_unary:
+                        setattr(self, unqualified_name, underlying_callable)
+
+    def add_to(self, server: grpc.Server) -> None:
+        """Adds all service handlers to server."""
+        for add in collect_servicer_add_functions(self.__class__):
+            add(self, server)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.shutdown()
+
+    def shutdown(self):
+        """
+        Shutdown what needs to be shutdown.
+
+        Typically, deferred RPC handlers.
+        """
+        for obj in self.needs_shutdown:
+            obj.shutdown()
+
+
+class TrackingUnaryUnaryRpcHandler(GeneralizedDecorator):
+    """A decorator for unary-unary gRPC handlers that tracks calls."""
+
+    def __init__(self, handler: typing.Callable) -> None:
+        super().__init__(handler)
+        self.requests: typing.List = []
+        self.num_calls = 0
+
+    def __call__(
+        self, request: typing.Any, context: grpc.ServicerContext
+    ) -> typing.Any:
+        try:
+            self.requests.append(request)
+            return self.__wrapped__(request, context)
+        finally:
+            self.num_calls += 1
+
+
+class TrackingStreamUnaryRpcHandler(GeneralizedDecorator):
+    """A decorator for stream-unary gRPC handlers that tracks calls."""
+
+    def __init__(self, handler: typing.Callable) -> None:
+        super().__init__(handler)
+        self.requests: typing.List = []
+        self.num_calls = 0
+
+    def __call__(
+        self, request_iterator: typing.Iterator, context: grpc.ServicerContext
+    ) -> typing.Any:
+        try:
+            request = list(request_iterator)
+            self.requests.append(request)
+            request_iterator = iter(request)
+            return self.__wrapped__(request_iterator, context)
+        finally:
+            self.num_calls += 1
+
+
+class TrackingUnaryStreamRpcHandler(GeneralizedDecorator):
+    """A decorator for unary-stream gRPC handlers that tracks calls."""
+
+    def __init__(self, handler: typing.Callable) -> None:
+        super().__init__(handler)
+        self.requests: typing.List = []
+        self.num_calls = 0
+
+    def __call__(
+        self, request: typing.Any, context: grpc.ServicerContext
+    ) -> typing.Iterator:
+        try:
+            self.requests.append(request)
+            yield from self.__wrapped__(request, context)
+        finally:
+            self.num_calls += 1
+
+
+class TrackingStreamStreamRpcHandler(GeneralizedDecorator):
+    """A decorator for stream-stream gRPC handlers that tracks calls."""
+
+    def __init__(self, handler: typing.Callable) -> None:
+        super().__init__(handler)
+        self.requests: typing.List = []
+        self.num_calls = 0
+
+    def __call__(
+        self, request_iterator: typing.Iterator, context: grpc.ServicerContext
+    ) -> typing.Iterator:
+        try:
+            request = list(request_iterator)
+            self.requests.append(request)
+            request_iterator = iter(request)
+            yield from self.__wrapped__(request_iterator, context)
+        finally:
+            self.num_calls += 1
+
+
+class DeferredRpcHandler(GeneralizedDecorator):
+    """
+    A gRPC handler that decouples invocation and computation execution paths.
+
+    By default, a call or invocation blocks the calling thread waiting for resolution,
+    which is thus deferred to another thread. Both request and context are made available
+    to the thread resolving the call or invocation. The response is fed back to the original
+    thread, which is then unblocked.
+
+    Invocations may also be resolved in advance, specifying future responses in absence of a request.
+    """
+
+    class Call:
+        """A deferred gRPC call to be resolved."""
+
+        def __init__(self, request: typing.Any, context: grpc.ServicerContext) -> None:
+            """
+            Args:
+                request: gRPC request object.
+                context: gRPC servicing context.
+            """
+            self._request = request
+            self._context = context
+            self._response: typing.Optional[typing.Any] = None
+            self._code: typing.Optional[grpc.StatusCode] = None
+            self._details: typing.Optional[str] = None
+            self._completed = False
+            self._completion = threading.Condition()
+
+        @property
+        def request(self) -> typing.Any:
+            """Call request."""
+            return self._request
+
+        @property
+        def context(self) -> grpc.ServicerContext:
+            """Call context."""
+            return self._context
+
+        @property
+        def response(self) -> typing.Optional[typing.Any]:
+            """Call response, if complete and successful."""
+            return self._response
+
+        @property
+        def code(self) -> typing.Optional[grpc.StatusCode]:
+            """Call code, if complete and failed."""
+            return self._code
+
+        @property
+        def details(self) -> typing.Optional[str]:
+            """Call details, if complete and failed."""
+            return self._details
+
+        def wait_for_completion(self, timeout: typing.Optional[float] = None) -> bool:
+            """
+            Waits for call completion.
+
+            Args:
+                timeout: time in seconds to wait for call completion.
+                If none is provided, it will wait indefinitely.
+
+            Returns:
+                true if call is completed, false otherwise.
+            """
+            with self._completion:
+                return self._completed or self._completion.wait(timeout)
+
+        def returns(self, response: typing.Any) -> None:
+            """Succeeds the call by returning a `response`."""
+            with self._completion:
+                if self._completed:
+                    raise RuntimeError("call already completed!")
+                self._response = response
+                self._completed = True
+                self._completion.notify_all()
+
+        def fails(
+            self, code: grpc.StatusCode, details: typing.Optional[str] = None
+        ) -> None:
+            """Fails the call by setting an error `code` and optional `details`."""
+            with self._completion:
+                if self._completed:
+                    raise RuntimeError("call already completed!")
+                self._code = code
+                self._details = details
+                self._completed = True
+                self._completion.notify_all()
+
+    class Future:
+        """
+        A window to future gRPC calls.
+
+        This helper class stores call resolutions in a FIFO queue,
+        for the handler to apply on future calls.
+        """
+
+        def __init__(self) -> None:
+            self._changequeue: queue.SimpleQueue = queue.SimpleQueue()
+
+        def materialize(self, call: "DeferredRpcHandler.Call") -> bool:
+            """Makes `call` the next call, applying the oldest resolution specified."""
+            try:
+                change = self._changequeue.get_nowait()
+                change(call)
+                return True
+            except queue.Empty:
+                return False
+
+        def returns(self, response: typing.Any) -> None:
+            """Specifies the next call will succeed with the given `response`."""
+            self._changequeue.put(lambda call: call.returns(response))
+
+        def fails(
+            self, code: grpc.StatusCode, details: typing.Optional[str] = None
+        ) -> None:
+            """Specifies the next call will fail with given error `code` and `details`."""
+            self._changequeue.put(lambda call: call.fails(code, details))
+
+    def __init__(self, handler: typing.Callable) -> None:
+        super().__init__(handler)
+        self._future = DeferredRpcHandler.Future()
+        self._callqueue: queue.SimpleQueue = queue.SimpleQueue()
+
+    def shutdown(self) -> None:
+        """Shutdown handler, aborting all pending calls."""
+        while not self._callqueue.empty():
+            call = self._callqueue.get_nowait()
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                logging.warning(
+                    f"{self.__name__} call not served, dropped during shutdown"
+                )
+            call.fails(grpc.StatusCode.ABORTED, "call dropped")
+
+    @property
+    def pending(self) -> bool:
+        """Whether a call is waiting to be served."""
+        return not self._callqueue.empty()
+
+    def serve(
+        self, timeout: typing.Optional[float] = None
+    ) -> typing.Optional["DeferredRpcHandler.Call"]:
+        """
+        Serve the next pending call, if any.
+
+        Args:
+            timeout: time in seconds to wait for a call.
+            If none is provided, it will wait indefinitely.
+
+        Returns:
+            a deferred call to be served or none on timeout.
+        """
+        try:
+            return self._callqueue.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    @property
+    def future(self) -> "DeferredRpcHandler.Future":
+        """The window to future calls."""
+        return self._future
+
+
+class DeferredUnaryRpcHandler(DeferredRpcHandler):
+    """A gRPC any-unary handler that decouples invocation and computation execution paths."""
+
+    def __call__(
+        self, request: typing.Any, context: grpc.ServicerContext
+    ) -> typing.Any:
+        call = DeferredRpcHandler.Call(request, context)
+        if not self._future.materialize(call):
+            self._callqueue.put(call)
+            call.wait_for_completion()
+        if not call.response:
+            context.abort(call.code, call.details)
+        return call.response
+
+
+class DeferredStreamRpcHandler(DeferredRpcHandler):
+    """A gRPC any-stream handler that decouples invocation and computation execution paths."""
+
+    def __call__(
+        self, request: typing.Any, context: grpc.ServicerContext
+    ) -> typing.Any:
+        call = DeferredRpcHandler.Call(request, context)
+        if not self._future.materialize(call):
+            self._callqueue.put(call)
+            call.wait_for_completion()
+        if call.response:
+            yield from call.response
+        else:
+            context.abort(call.code, call.details)

--- a/spot_wrapper/testing/helpers.py
+++ b/spot_wrapper/testing/helpers.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import functools
+import typing
+
+import grpc
+from bosdyn.api.header_pb2 import CommonError
+from bosdyn.api.lease_pb2 import ResourceTree
+
+
+class GeneralizedDecorator:
+    __name__ = __qualname__ = __doc__ = ""
+
+    __annotations__ = {}
+
+    @staticmethod
+    def wraps(wrapped: typing.Callable):
+        def decorator(func: typing.Callable):
+            class wrapper(GeneralizedDecorator):
+                def __call__(
+                    self, *args: typing.Any, **kwargs: typing.Any
+                ) -> typing.Any:
+                    return func(*args, **kwargs)
+
+            return wrapper(wrapped)
+
+        return decorator
+
+    def __init__(self, wrapped: typing.Callable) -> None:
+        functools.update_wrapper(self, wrapped, updated=[])
+
+    def __getattr__(self, name: str) -> typing.Any:
+        return getattr(self.__wrapped__, name)
+
+    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        raise NotImplementedError()
+
+
+UnaryUnaryHandlerCallable = typing.Callable[
+    [typing.Any, grpc.ServicerContext], typing.Any
+]
+
+
+def enforce_matching_headers(
+    handler: UnaryUnaryHandlerCallable,
+) -> UnaryUnaryHandlerCallable:
+    """Enforce headers for handler request and response match (by copy)."""
+
+    @GeneralizedDecorator.wraps(handler)
+    def wrapper(request: typing.Any, context: grpc.ServicerContext) -> typing.Any:
+        response = handler(request, context)
+        if hasattr(request, "header") and hasattr(response, "header"):
+            response.header.request_header.CopyFrom(request.header)
+            response.header.request_received_timestamp.CopyFrom(
+                request.header.request_timestamp
+            )
+            response.header.error.code = (
+                response.header.error.code or CommonError.CODE_OK
+            )
+        return response
+
+    return wrapper
+
+
+def walk_resource_tree(resource_tree: ResourceTree) -> typing.Iterable[ResourceTree]:
+    """Walks `resource_tree` top-down, depth-first."""
+    yield resource_tree
+    for subtree in resource_tree.sub_resources:
+        yield from walk_resource_tree(subtree)

--- a/spot_wrapper/testing/mocks/__init__.py
+++ b/spot_wrapper/testing/mocks/__init__.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import typing
+
+from bosdyn.api.arm_surface_contact_service_pb2_grpc import (
+    ArmSurfaceContactServiceServicer,
+)
+from bosdyn.api.auth_service_pb2_grpc import AuthServiceServicer
+from bosdyn.api.auto_return.auto_return_service_pb2_grpc import (
+    AutoReturnServiceServicer,
+)
+from bosdyn.api.autowalk.autowalk_service_pb2_grpc import AutowalkServiceServicer
+from bosdyn.api.data_acquisition_plugin_service_pb2_grpc import (
+    DataAcquisitionPluginServiceServicer,
+)
+from bosdyn.api.data_acquisition_store_service_pb2_grpc import (
+    DataAcquisitionStoreServiceServicer,
+)
+from bosdyn.api.data_buffer_service_pb2_grpc import DataBufferServiceServicer
+from bosdyn.api.data_service_pb2_grpc import DataServiceServicer
+from bosdyn.api.directory_registration_service_pb2_grpc import (
+    DirectoryRegistrationServiceServicer,
+)
+from bosdyn.api.directory_service_pb2_grpc import DirectoryServiceServicer
+from bosdyn.api.docking.docking_service_pb2_grpc import DockingServiceServicer
+from bosdyn.api.estop_service_pb2_grpc import EstopServiceServicer
+from bosdyn.api.fault_service_pb2_grpc import FaultServiceServicer
+from bosdyn.api.graph_nav.area_callback_service_pb2_grpc import (
+    AreaCallbackServiceServicer,
+)
+from bosdyn.api.graph_nav.graph_nav_service_pb2_grpc import GraphNavServiceServicer
+from bosdyn.api.graph_nav.map_processing_service_pb2_grpc import (
+    MapProcessingServiceServicer,
+)
+from bosdyn.api.graph_nav.recording_service_pb2_grpc import (
+    GraphNavRecordingServiceServicer,
+)
+from bosdyn.api.gripper_camera_param_service_pb2_grpc import (
+    GripperCameraParamServiceServicer,
+)
+from bosdyn.api.image_service_pb2_grpc import ImageServiceServicer
+from bosdyn.api.ir_enable_disable_service_pb2_grpc import IREnableDisableServiceServicer
+from bosdyn.api.keepalive.keepalive_service_pb2_grpc import KeepaliveServiceServicer
+from bosdyn.api.lease_service_pb2_grpc import LeaseServiceServicer
+from bosdyn.api.license_service_pb2_grpc import LicenseServiceServicer
+from bosdyn.api.local_grid_service_pb2_grpc import LocalGridServiceServicer
+from bosdyn.api.log_status.log_status_service_pb2_grpc import LogStatusServiceServicer
+from bosdyn.api.manipulation_api_service_pb2_grpc import ManipulationApiServiceServicer
+from bosdyn.api.mission.mission_service_pb2_grpc import MissionServiceServicer
+from bosdyn.api.mission.remote_service_pb2_grpc import RemoteMissionServiceServicer
+from bosdyn.api.network_compute_bridge_service_pb2_grpc import (
+    NetworkComputeBridgeWorkerServicer,
+)
+from bosdyn.api.payload_registration_service_pb2_grpc import (
+    PayloadRegistrationServiceServicer,
+)
+from bosdyn.api.payload_service_pb2_grpc import PayloadServiceServicer
+from bosdyn.api.point_cloud_service_pb2_grpc import PointCloudServiceServicer
+from bosdyn.api.power_service_pb2_grpc import (
+    PowerServiceServicer as PowerCommandServiceServicer,
+)
+from bosdyn.api.robot_command_service_pb2_grpc import RobotCommandServiceServicer
+from bosdyn.api.robot_id_service_pb2_grpc import RobotIdServiceServicer
+from bosdyn.api.robot_state_service_pb2_grpc import RobotStateServiceServicer
+from bosdyn.api.spot.choreography_service_pb2_grpc import ChoreographyServiceServicer
+from bosdyn.api.spot.door_service_pb2_grpc import DoorServiceServicer
+from bosdyn.api.spot.inverse_kinematics_service_pb2_grpc import (
+    InverseKinematicsServiceServicer,
+)
+from bosdyn.api.spot.spot_check_service_pb2_grpc import SpotCheckServiceServicer
+from bosdyn.api.spot_cam.service_pb2_grpc import (
+    AudioServiceServicer,
+    CompositorServiceServicer,
+    HealthServiceServicer,
+    LightingServiceServicer,
+    MediaLogServiceServicer,
+    NetworkServiceServicer,
+    PowerServiceServicer,
+    PtzServiceServicer,
+    StreamQualityServiceServicer,
+    VersionServiceServicer,
+)
+from bosdyn.api.time_sync_service_pb2_grpc import TimeSyncServiceServicer
+from bosdyn.api.world_object_service_pb2_grpc import WorldObjectServiceServicer
+
+from spot_wrapper.testing.grpc import AutoServicer, collect_method_handlers
+from spot_wrapper.testing.helpers import enforce_matching_headers
+from spot_wrapper.testing.mocks.auth import MockAuthService
+from spot_wrapper.testing.mocks.directory import MockDirectoryService
+from spot_wrapper.testing.mocks.estop import MockEStopService
+from spot_wrapper.testing.mocks.keepalive import MockKeepaliveService
+from spot_wrapper.testing.mocks.lease import MockLeaseService
+from spot_wrapper.testing.mocks.license import MockLicenseService
+from spot_wrapper.testing.mocks.payload_registration import (
+    MockPayloadRegistrationService,
+)
+from spot_wrapper.testing.mocks.robot_id import MockRobotIdService
+from spot_wrapper.testing.mocks.robot_state import MockRobotStateService
+from spot_wrapper.testing.mocks.time_sync import MockTimeSyncService
+
+
+class BaseMockSpot(
+    AutoServicer,
+    AreaCallbackServiceServicer,
+    ArmSurfaceContactServiceServicer,
+    AudioServiceServicer,
+    AuthServiceServicer,
+    AutoReturnServiceServicer,
+    AutowalkServiceServicer,
+    ChoreographyServiceServicer,
+    CompositorServiceServicer,
+    DataAcquisitionPluginServiceServicer,
+    DataAcquisitionStoreServiceServicer,
+    DataBufferServiceServicer,
+    DataServiceServicer,
+    DirectoryRegistrationServiceServicer,
+    DirectoryServiceServicer,
+    DockingServiceServicer,
+    DoorServiceServicer,
+    EstopServiceServicer,
+    FaultServiceServicer,
+    GraphNavRecordingServiceServicer,
+    GraphNavServiceServicer,
+    GripperCameraParamServiceServicer,
+    HealthServiceServicer,
+    IREnableDisableServiceServicer,
+    ImageServiceServicer,
+    InverseKinematicsServiceServicer,
+    KeepaliveServiceServicer,
+    LeaseServiceServicer,
+    LicenseServiceServicer,
+    LightingServiceServicer,
+    LocalGridServiceServicer,
+    LogStatusServiceServicer,
+    ManipulationApiServiceServicer,
+    MapProcessingServiceServicer,
+    MediaLogServiceServicer,
+    MissionServiceServicer,
+    NetworkComputeBridgeWorkerServicer,
+    NetworkServiceServicer,
+    PayloadRegistrationServiceServicer,
+    PayloadServiceServicer,
+    PointCloudServiceServicer,
+    PowerCommandServiceServicer,
+    PowerServiceServicer,
+    PtzServiceServicer,
+    RemoteMissionServiceServicer,
+    RobotCommandServiceServicer,
+    RobotIdServiceServicer,
+    RobotStateServiceServicer,
+    SpotCheckServiceServicer,
+    StreamQualityServiceServicer,
+    TimeSyncServiceServicer,
+    VersionServiceServicer,
+    WorldObjectServiceServicer,
+):
+    """
+    Base Spot mock.
+
+    It implements nothing.
+    """
+
+    name = "mockie"
+
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        super().__init__(*args, **kwargs)
+        for _, handler in collect_method_handlers(self):
+            if handler.request_streaming:
+                continue
+            if handler.response_streaming:
+                continue
+            setattr(
+                self,
+                handler.unary_unary.__name__,
+                enforce_matching_headers(handler.unary_unary),
+            )
+
+
+class MockSpot(
+    BaseMockSpot,
+    MockAuthService,
+    MockDirectoryService,
+    MockEStopService,
+    MockKeepaliveService,
+    MockLeaseService,
+    MockLicenseService,
+    MockPayloadRegistrationService,
+    MockRobotIdService,
+    MockRobotStateService,
+    MockTimeSyncService,
+):
+    """
+    Nominal Spot mock.
+
+    It implements the bare minimum for Spot wrapper initialization.
+    For the rest, it relies on automatic specification.
+    """
+
+    autospec = True

--- a/spot_wrapper/testing/mocks/auth.py
+++ b/spot_wrapper/testing/mocks/auth.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import grpc
+from bosdyn.api.auth_pb2 import GetAuthTokenRequest, GetAuthTokenResponse
+from bosdyn.api.auth_service_pb2_grpc import AuthServiceServicer
+
+
+class MockAuthService(AuthServiceServicer):
+    """A mock Spot authentication service."""
+
+    def GetAuthToken(
+        self, request: GetAuthTokenRequest, context: grpc.ServicerContext
+    ) -> GetAuthTokenResponse:
+        response = GetAuthTokenResponse()
+        response.status = GetAuthTokenResponse.Status.STATUS_OK
+        response.token = "mock-token"
+        return response

--- a/spot_wrapper/testing/mocks/directory.py
+++ b/spot_wrapper/testing/mocks/directory.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import typing
+
+import grpc
+import inflection
+from bosdyn.api.directory_pb2 import (
+    GetServiceEntryRequest,
+    GetServiceEntryResponse,
+    ListServiceEntriesRequest,
+    ListServiceEntriesResponse,
+    ServiceEntry,
+)
+from bosdyn.api.directory_service_pb2_grpc import DirectoryServiceServicer
+
+from spot_wrapper.testing.grpc import collect_service_types
+
+
+class MockDirectoryService(DirectoryServiceServicer):
+    """
+    A mock Spot directory service.
+
+    By default it yields all services implemented by its class,
+    using default authority and name conventions.
+    """
+
+    # Manage services with special names and/or authority.
+    DEFAULT_SERVICES = {
+        entry.type: entry
+        for entry in [
+            ServiceEntry(
+                name="auth", type="bosdyn.api.AuthService", authority="auth.spot.robot"
+            ),
+            ServiceEntry(
+                name="payload-registration",
+                type="bosdyn.api.RobotIdService",
+                authority="id.spot.robot",
+            ),
+            ServiceEntry(
+                name="payload-registration",
+                type="bosdyn.api.PayloadRegistrationService",
+                authority="payload-registration.spot.robot",
+            ),
+            ServiceEntry(
+                name="robot-id",
+                type="bosdyn.api.RobotIdService",
+                authority="id.spot.robot",
+            ),
+            ServiceEntry(
+                name="world-objects",
+                type="bosdyn.api.WorldObjectService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="graph-nav-service",
+                type="bosdyn.api.graph_nav.GraphNavService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="map-processing-service",
+                type="bosdyn.api.graph_nav.MapProcessingService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="ray-cast",
+                type="bosdyn.api.RayCastService",
+                authority="ray-cast.spot.robot",
+            ),
+            ServiceEntry(
+                name="autowalk-service",
+                type="bosdyn.api.autowalk.AutowalkService",
+                authority="ray-cast.spot.robot",
+            ),
+            ServiceEntry(
+                name="manipulation",
+                type="bosdyn.api.ManipulationApiService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-audio",
+                type="bosdyn.api.spot_cam.AudioService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-compositor",
+                type="bosdyn.api.spot_cam.CompositorService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-health",
+                type="bosdyn.api.spot_cam.HealthService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-lighting",
+                type="bosdyn.api.spot_cam.LightingService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-media-log",
+                type="bosdyn.api.spot_cam.MediaLogService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-network",
+                type="bosdyn.api.spot_cam.NetworkService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-power",
+                type="bosdyn.api.spot_cam.PowerService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-ptz",
+                type="bosdyn.api.spot_cam.PtzService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-stream-quality",
+                type="bosdyn.api.spot_cam.StreamQualityService",
+                authority="api.spot.robot",
+            ),
+            ServiceEntry(
+                name="spot-cam-version",
+                type="bosdyn.api.spot_cam.VersionService",
+                authority="api.spot.robot",
+            ),
+        ]
+    }
+
+    def __init__(
+        self,
+        *,
+        services: typing.Optional[typing.Iterable[ServiceEntry]] = None,
+        **kwargs: typing.Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if services is None:
+            services = []
+            for service_type in collect_service_types(self):
+                entry = ServiceEntry()
+                if service_type not in self.DEFAULT_SERVICES:
+                    _, _, service_typename = service_type.rpartition(".")
+                    service_name = service_typename.removesuffix("Service")
+                    service_name = inflection.underscore(service_name).replace("_", "-")
+                    entry.type = service_type
+                    entry.name = service_name
+                    entry.authority = "api.spot.robot"
+                else:
+                    entry.CopyFrom(self.DEFAULT_SERVICES[service_type])
+                services.append(entry)
+        self._services = {entry.name: entry for entry in services}
+
+    def GetServiceEntry(
+        self, request: GetServiceEntryRequest, context: grpc.ServicerContext
+    ) -> GetServiceEntryResponse:
+        response = GetServiceEntryResponse()
+        if request.service_name not in self._services:
+            response.status = GetServiceEntryResponse.Status.STATUS_NONEXISTENT_SERVICE
+            return response
+        response.service_entry.CopyFrom(self._services[request.service_name])
+        return response
+
+    def ListServiceEntries(
+        self, request: ListServiceEntriesRequest, context: grpc.ServicerContext
+    ) -> ListServiceEntriesResponse:
+        response = ListServiceEntriesResponse()
+        response.service_entries.extend(self._services.values())
+        return response

--- a/spot_wrapper/testing/mocks/estop.py
+++ b/spot_wrapper/testing/mocks/estop.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import itertools
+import typing
+
+import grpc
+from bosdyn.api.estop_pb2 import (
+    DeregisterEstopEndpointRequest,
+    DeregisterEstopEndpointResponse,
+    EstopCheckInRequest,
+    EstopCheckInResponse,
+    EstopConfig,
+    EstopStopLevel,
+    GetEstopConfigRequest,
+    GetEstopConfigResponse,
+    GetEstopSystemStatusRequest,
+    GetEstopSystemStatusResponse,
+    RegisterEstopEndpointRequest,
+    RegisterEstopEndpointResponse,
+    SetEstopConfigRequest,
+    SetEstopConfigResponse,
+)
+from bosdyn.api.estop_service_pb2_grpc import EstopServiceServicer
+from bosdyn.api.header_pb2 import CommonError
+
+
+class MockEStopService(EstopServiceServicer):
+    """
+    A mock Spot e-stop service.
+
+    It provides a license that never expires for all features.
+    """
+
+    def __init__(self, **kwargs: typing.Any) -> None:
+        super().__init__(**kwargs)
+        self._config_id_generator = (f"config#{i}" for i in itertools.count())
+        self._endpoint_id_generator = (f"endpoint#{i}" for i in itertools.count())
+        self.active_estop_configuration = EstopConfig()
+        self.active_estop_configuration.unique_id = next(self._config_id_generator)
+        self.estop_configurations = [self.active_estop_configuration]
+
+    def RegisterEstopEndpoint(
+        self, request: RegisterEstopEndpointRequest, context: grpc.ServicerContext
+    ) -> RegisterEstopEndpointResponse:
+        response = RegisterEstopEndpointResponse()
+        response.request.CopyFrom(request)
+        estop_configurations = {
+            config.unique_id: config for config in self.estop_configurations
+        }
+        if request.target_config_id not in estop_configurations:
+            response.status = (
+                RegisterEstopEndpointResponse.Status.STATUS_CONFIG_MISMATCH
+            )
+            return response
+        estop_configuration = estop_configurations[request.target_config_id]
+        if request.target_endpoint.unique_id:
+            estop_endpoints = {ep.unique_id: ep for ep in estop_configuration.endpoints}
+            if request.target_endpoint.unique_id not in estop_endpoints:
+                response.status = (
+                    RegisterEstopEndpointResponse.Status.STATUS_ENDPOINT_MISMATCH
+                )
+                return response
+            estop_endpoint = estop_endpoints[request.target_endpoint.unique_id]
+        else:
+            estop_endpoint = estop_configuration.endpoints.add()
+            estop_endpoint.unique_id = next(self._endpoint_id_generator)
+        unique_id = estop_endpoint.unique_id
+        estop_endpoint.CopyFrom(request.new_endpoint)
+        estop_endpoint.unique_id = unique_id
+        response.new_endpoint.CopyFrom(estop_endpoint)
+        response.status = RegisterEstopEndpointResponse.Status.STATUS_SUCCESS
+        return response
+
+    def DeregisterEstopEndpoint(
+        self, request: DeregisterEstopEndpointRequest, context: grpc.ServicerContext
+    ) -> DeregisterEstopEndpointResponse:
+        response = DeregisterEstopEndpointResponse()
+        response.request.CopyFrom(request)
+        estop_configurations = {
+            config.unique_id: config for config in self.estop_configurations
+        }
+        if request.target_config_id not in estop_configurations:
+            response.status = (
+                RegisterEstopEndpointResponse.Status.STATUS_CONFIG_MISMATCH
+            )
+            return response
+        estop_configuration = estop_configurations[request.target_config_id]
+        estop_endpoint_indices = {
+            ep.unique_id: index
+            for index, ep in enumerate(estop_configuration.endpoints)
+        }
+        if request.target_endpoint.unique_id not in estop_endpoint_indices:
+            response.status = (
+                RegisterEstopEndpointResponse.Status.STATUS_ENDPOINT_MISMATCH
+            )
+            return response
+        del estop_configuration.endpoints[
+            estop_endpoint_indices[request.target_endpoint.unique_id]
+        ]
+        response.status = DeregisterEstopEndpointResponse.Status.STATUS_SUCCESS
+        return response
+
+    def EstopCheckIn(
+        self, request: EstopCheckInRequest, context: grpc.ServicerContext
+    ) -> EstopCheckInResponse:
+        response = EstopCheckInResponse()
+        response.request.CopyFrom(request)
+        estop_endpoints = {
+            ep.unique_id: ep
+            for cfg in self.estop_configurations
+            for ep in cfg.endpoints
+        }
+        if request.endpoint.unique_id not in estop_endpoints:
+            response.status = EstopCheckInResponse.Status.STATUS_ENDPOINT_UNKNOWN
+            return response
+        response.status = EstopCheckInResponse.Status.STATUS_OK
+        response.challenge = (request.challenge or 1) + 1
+        return response
+
+    def GetEstopConfig(
+        self, request: GetEstopConfigRequest, context: grpc.ServicerContext
+    ) -> GetEstopConfigResponse:
+        response = GetEstopConfigResponse()
+        response.request.CopyFrom(request)
+        if not request.target_config_id:
+            response.active_config.CopyFrom(self.active_estop_configuration)
+            return response
+        estop_configurations = {
+            config.unique_id: config for config in self.estop_configurations
+        }
+        if request.target_config_id not in estop_configurations:
+            response.header.error.code = CommonError.CODE_INVALID_REQUEST
+            return response
+        response.active_config.CopyFrom(estop_configurations[request.target_config_id])
+        return response
+
+    def SetEstopConfig(
+        self, request: SetEstopConfigRequest, context: grpc.ServicerContext
+    ) -> SetEstopConfigResponse:
+        response = SetEstopConfigResponse()
+        response.request.CopyFrom(request)
+        if request.target_config_id:
+            estop_configurations = {
+                config.unique_id: config for config in self.estop_configurations
+            }
+            if request.target_config_id not in estop_configurations:
+                response.status = SetEstopConfigResponse.Status.STATUS_INVALID_ID
+                return response
+            self.active_estop_configuration = estop_configurations[
+                request.target_config_id
+            ]
+        else:
+            self.active_estop_configuration = EstopConfig()
+            self.active_estop_configuration.unique_id = next(self._config_id_generator)
+            self.estop_configurations.append(self.active_estop_configuration)
+        self.active_estop_configuration.CopyFrom(request.config)
+        response.active_config.CopyFrom(self.active_estop_configuration)
+        response.status = SetEstopConfigResponse.Status.STATUS_SUCCESS
+        return response
+
+    def GetEstopSystemStatus(
+        self, request: GetEstopSystemStatusRequest, context: grpc.ServicerContext
+    ) -> GetEstopSystemStatusResponse:
+        response = GetEstopSystemStatusResponse()
+        for cfg in self.estop_configurations:
+            for ep in cfg.endpoints:
+                endpoint_with_status = response.status.endpoints.add()
+                endpoint_with_status.endpoint.CopyFrom(ep)
+                endpoint_with_status.stop_level = EstopStopLevel.ESTOP_LEVEL_NONE
+        response.stop_level = EstopStopLevel.ESTOP_LEVEL_NONE
+        return response

--- a/spot_wrapper/testing/mocks/keepalive.py
+++ b/spot_wrapper/testing/mocks/keepalive.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import itertools
+import typing
+
+import grpc
+from bosdyn.api.keepalive.keepalive_pb2 import (
+    CheckInRequest,
+    CheckInResponse,
+    GetStatusRequest,
+    GetStatusResponse,
+    LivePolicy,
+    ModifyPolicyRequest,
+    ModifyPolicyResponse,
+)
+from bosdyn.api.keepalive.keepalive_service_pb2_grpc import KeepaliveServiceServicer
+
+
+class MockKeepaliveService(KeepaliveServiceServicer):
+    """
+    A mock Spot keep-alive service.
+
+    It bookkeeps all policies but enforces none.
+    """
+
+    def __init__(self, **kwargs: typing.Any) -> None:
+        super().__init__(**kwargs)
+        self._policy_ids = itertools.count()
+        self._policies: typing.Dict[int, LivePolicy] = {}
+
+    @property
+    def policies(self) -> typing.Iterable[LivePolicy]:
+        return self._policies.values()
+
+    def ModifyPolicy(
+        self, request: ModifyPolicyRequest, context: grpc.ServicerContext
+    ) -> ModifyPolicyResponse:
+        response = ModifyPolicyResponse()
+
+        for policy_id in request.policy_ids_to_remove:
+            if policy_id not in self._policies:
+                response.status = ModifyPolicyResponse.Status.STATUS_INVALID_POLICY_ID
+                return response
+            live_policy = self._policies[policy_id]
+            response.removed_policies.append(live_policy)
+            del self._policies[policy_id]
+
+        if request.HasField("to_add"):
+            live_policy = LivePolicy()
+            live_policy.policy.CopyFrom(request.to_add)
+            live_policy.policy_id = next(self._policy_ids)
+            live_policy.client_name = request.header.client_name
+            live_policy.last_checkin.CopyFrom(request.header.request_timestamp)
+            self._policies[live_policy.policy_id] = live_policy
+            response.added_policy.CopyFrom(live_policy)
+
+        response.status = ModifyPolicyResponse.Status.STATUS_OK
+        return response
+
+    def CheckIn(
+        self, request: CheckInRequest, context: grpc.ServicerContext
+    ) -> CheckInResponse:
+        response = CheckInResponse()
+        if request.policy_id not in self._policies:
+            response.status = CheckInResponse.Status.STATUS_INVALID_POLICY_ID
+            return response
+        live_policy = self._policies[request.policy_id]
+        live_policy.last_checkin.CopyFrom(request.header.request_timestamp)
+        response.status = CheckInResponse.Status.STATUS_OK
+        return response
+
+    def GetStatus(
+        self, request: GetStatusRequest, context: grpc.ServicerContext
+    ) -> GetStatusResponse:
+        response = GetStatusResponse()
+        response.status.extend(self._policies.values())
+        return response

--- a/spot_wrapper/testing/mocks/lease.py
+++ b/spot_wrapper/testing/mocks/lease.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import typing
+
+import grpc
+from bosdyn.api.lease_pb2 import (
+    AcquireLeaseRequest,
+    AcquireLeaseResponse,
+    Lease,
+    LeaseResource,
+    LeaseUseResult,
+    ListLeasesRequest,
+    ListLeasesResponse,
+    ResourceTree,
+    RetainLeaseRequest,
+    RetainLeaseResponse,
+    ReturnLeaseRequest,
+    ReturnLeaseResponse,
+    TakeLeaseRequest,
+    TakeLeaseResponse,
+)
+from bosdyn.api.lease_service_pb2_grpc import LeaseServiceServicer
+
+from spot_wrapper.testing.helpers import walk_resource_tree
+
+
+class MockLeaseService(LeaseServiceServicer):
+    """
+    A mock Spot lease service.
+
+    By default it uses a minimal resource tree. Lease staling times are not enforced.
+    """
+
+    def __init__(
+        self,
+        *,
+        resource_tree: typing.Optional[ResourceTree] = None,
+        **kwargs: typing.Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if resource_tree is None:
+            resource_tree = ResourceTree()
+            resource_tree.resource = "all-leases"
+            subtree = resource_tree.sub_resources.add()
+            subtree.resource = "body"
+        self._resource_tree = resource_tree
+        self._leasable_resources: typing.Dict[str, LeaseResource] = {}
+        for i, resource in enumerate(walk_resource_tree(resource_tree)):
+            leasable_resource = LeaseResource()
+            leasable_resource.resource = resource.resource
+            leasable_resource.lease.resource = resource.resource
+            leasable_resource.lease.sequence.append(i)
+            leasable_resource.lease.epoch = "mock-epoch"
+            leasable_resource.is_stale = True
+            self._leasable_resources[resource.resource] = leasable_resource
+        self._latest_lease: typing.Optional[Lease] = None
+
+    def AcquireLease(
+        self, request: AcquireLeaseRequest, context: grpc.ServicerContext
+    ) -> AcquireLeaseResponse:
+        response = AcquireLeaseResponse()
+        if request.resource not in self._leasable_resources:
+            response.status = AcquireLeaseResponse.Status.STATUS_INVALID_RESOURCE
+            return response
+        leasable_resource = self._leasable_resources[request.resource]
+        if not leasable_resource.is_stale:
+            response.status = (
+                AcquireLeaseResponse.Status.STATUS_RESOURCE_ALREADY_CLAIMED
+            )
+            response.lease_owner.CopyFrom(leasable_resource.lease_owner)
+            return response
+        leasable_resource.lease.client_names.append(request.header.client_name)
+        if self._latest_lease is None:
+            self._latest_lease = Lease()
+        self._latest_lease.CopyFrom(leasable_resource.lease)
+        leasable_resource.lease_owner.client_name = request.header.client_name
+        leasable_resource.is_stale = False
+        response.lease.CopyFrom(leasable_resource.lease)
+        response.lease_owner.CopyFrom(leasable_resource.lease_owner)
+        response.status = AcquireLeaseResponse.Status.STATUS_OK
+        return response
+
+    def TakeLease(
+        self, request: TakeLeaseRequest, context: grpc.ServicerContext
+    ) -> TakeLeaseResponse:
+        response = TakeLeaseResponse()
+        if request.resource not in self._leasable_resources:
+            response.status = TakeLeaseResponse.Status.STATUS_INVALID_RESOURCE
+            return response
+        leasable_resource = self._leasable_resources[request.resource]
+        leasable_resource.lease.client_names.append(request.header.client_name)
+        if self._latest_lease is None:
+            self._latest_lease = Lease()
+        self._latest_lease.CopyFrom(leasable_resource.lease)
+        leasable_resource.lease_owner.client_name = request.header.client_name
+        leasable_resource.is_stale = False
+        response.lease.CopyFrom(leasable_resource.lease)
+        response.lease_owner.CopyFrom(leasable_resource.lease_owner)
+        response.status = TakeLeaseResponse.Status.STATUS_OK
+        return response
+
+    def ReturnLease(
+        self, request: ReturnLeaseRequest, context: grpc.ServicerContext
+    ) -> ReturnLeaseResponse:
+        response = ReturnLeaseResponse()
+        if request.lease.resource not in self._leasable_resources:
+            response.status = ReturnLeaseResponse.Status.STATUS_INVALID_RESOURCE
+            return response
+        leasable_resource = self._leasable_resources[request.lease.resource]
+        if leasable_resource.is_stale:
+            response.status = ReturnLeaseResponse.Status.STATUS_NOT_ACTIVE_LEASE
+            return response
+        leasable_resource.is_stale = True
+        leasable_resource.ClearField("lease_owner")
+        response.status = ReturnLeaseResponse.Status.STATUS_OK
+        return response
+
+    def ListLeases(
+        self, request: ListLeasesRequest, context: grpc.ServicerContext
+    ) -> ListLeasesResponse:
+        response = ListLeasesResponse()
+        response.resources.extend(self._leasable_resources.values())
+        response.resource_tree.CopyFrom(self._resource_tree)
+        return response
+
+    def RetainLease(
+        self, request: RetainLeaseRequest, context: grpc.ServicerContext
+    ) -> RetainLeaseResponse:
+        response = RetainLeaseResponse()
+        response.lease_use_result.attempted_lease.CopyFrom(request.lease)
+        if self._latest_lease is not None:
+            response.lease_use_result.latest_known_lease.CopyFrom(self._latest_lease)
+        if request.lease.resource not in self._leasable_resources:
+            response.lease_use_result.status = (
+                LeaseUseResult.Status.STATUS_INVALID_LEASE
+            )
+            return response
+        leasable_resource = self._leasable_resources[request.lease.resource]
+        if leasable_resource.is_stale:
+            response.lease_use_result.status = LeaseUseResult.Status.STATUS_REVOKED
+            return response
+        response.lease_use_result.owner.CopyFrom(leasable_resource.lease_owner)
+        response.lease_use_result.status = LeaseUseResult.Status.STATUS_OK
+        return response

--- a/spot_wrapper/testing/mocks/license.py
+++ b/spot_wrapper/testing/mocks/license.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import grpc
+from bosdyn.api.license_pb2 import (
+    GetFeatureEnabledRequest,
+    GetFeatureEnabledResponse,
+    GetLicenseInfoRequest,
+    GetLicenseInfoResponse,
+    LicenseInfo,
+)
+from bosdyn.api.license_service_pb2_grpc import LicenseServiceServicer
+
+
+class MockLicenseService(LicenseServiceServicer):
+    """
+    A mock Spot license service.
+
+    It provides a license that never expires for all features.
+    """
+
+    def GetLicenseInfo(
+        self, request: GetLicenseInfoRequest, context: grpc.ServicerContext
+    ) -> GetLicenseInfoResponse:
+        response = GetLicenseInfoResponse()
+        response.license.status = LicenseInfo.Status.STATUS_VALID
+        response.license.id = "0123210"
+        response.license.robot_serial = "1234567890"
+        response.licensed_features.append("choreography")
+        return response
+
+    def GetFeatureEnabled(
+        self, request: GetFeatureEnabledRequest, context: grpc.ServicerContext
+    ) -> GetFeatureEnabledResponse:
+        response = GetFeatureEnabledResponse()
+        for feature_code in request.feature_codes:
+            response.feature_enabled[feature_code] = True
+        return response

--- a/spot_wrapper/testing/mocks/payload_registration.py
+++ b/spot_wrapper/testing/mocks/payload_registration.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import typing
+
+import grpc
+from bosdyn.api.payload_pb2 import Payload
+from bosdyn.api.payload_registration_pb2 import (
+    GetPayloadAuthTokenRequest,
+    GetPayloadAuthTokenResponse,
+    RegisterPayloadRequest,
+    RegisterPayloadResponse,
+    UpdatePayloadAttachedRequest,
+    UpdatePayloadAttachedResponse,
+    UpdatePayloadVersionRequest,
+    UpdatePayloadVersionResponse,
+)
+from bosdyn.api.payload_registration_service_pb2_grpc import (
+    PayloadRegistrationServiceServicer,
+)
+
+
+class MockPayloadRegistrationService(PayloadRegistrationServiceServicer):
+    """
+    A mock Spot payload registration service.
+
+    It bookkeeps all payloads but enforces nothing.
+    """
+
+    def __init__(self, **kwargs: typing.Any) -> None:
+        super().__init__(**kwargs)
+        self._payloads: typing.Dict[str, Payload] = {}
+
+    def RegisterPayload(
+        self, request: RegisterPayloadRequest, context: grpc.ServicerContext
+    ) -> RegisterPayloadResponse:
+        response = RegisterPayloadResponse()
+        if request.payload.GUID in self._payloads:
+            response.status = RegisterPayloadResponse.Status.STATUS_ALREADY_EXISTS
+            return response
+        payload = Payload()
+        payload.CopyFrom(request.payload)
+        self._payloads[payload.GUID] = payload
+        response.status = RegisterPayloadResponse.Status.STATUS_OK
+        return response
+
+    def UpdatePayloadVersion(
+        self, request: UpdatePayloadVersionRequest, context: grpc.ServicerContext
+    ) -> UpdatePayloadVersionResponse:
+        response = UpdatePayloadVersionResponse()
+        if request.payload_credentials.guid not in self._payloads:
+            response.status = UpdatePayloadAttachedResponse.Status.STATUS_DOES_NOT_EXIST
+            return response
+        response.status = UpdatePayloadAttachedResponse.Status.STATUS_OK
+        return response
+
+    def GetPayloadAuthToken(
+        self, request: GetPayloadAuthTokenRequest, context: grpc.ServicerContext
+    ) -> GetPayloadAuthTokenResponse:
+        response = GetPayloadAuthTokenResponse()
+        if request.payload_credentials.guid not in self._payloads:
+            response.status = (
+                GetPayloadAuthTokenResponse.Status.STATUS_INVALID_CREDENTIALS
+            )
+            return response
+        response.status = GetPayloadAuthTokenResponse.Status.STATUS_OK
+        response.token = "mock-payload-token"
+        return response
+
+    def UpdatePayloadAttached(
+        self, request: UpdatePayloadAttachedRequest, context: grpc.ServicerContext
+    ) -> UpdatePayloadAttachedResponse:
+        response = UpdatePayloadAttachedResponse()
+        if request.payload_credentials.guid not in self._payloads:
+            response.status = UpdatePayloadAttachedResponse.Status.STATUS_DOES_NOT_EXIST
+            return response
+        response.status = UpdatePayloadAttachedResponse.Status.STATUS_OK
+        return response

--- a/spot_wrapper/testing/mocks/robot_id.py
+++ b/spot_wrapper/testing/mocks/robot_id.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import grpc
+from bosdyn.api.robot_id_pb2 import RobotIdRequest, RobotIdResponse
+from bosdyn.api.robot_id_service_pb2_grpc import RobotIdServiceServicer
+
+
+class MockRobotIdService(RobotIdServiceServicer):
+    """A mock Spot robot id service."""
+
+    def GetRobotId(
+        self, request: RobotIdRequest, context: grpc.ServicerContext
+    ) -> RobotIdResponse:
+        response = RobotIdResponse()
+        response.robot_id.serial_number = "1234567890"
+        response.robot_id.species = "mock-spot"
+        response.robot_id.version = "0.0.0"
+        response.robot_id.nickname = self.name
+        response.robot_id.computer_serial_number = "1234567890ABCDEF"
+        response.robot_id.software_release.version.major_version = 0
+        response.robot_id.software_release.version.minor_version = 0
+        response.robot_id.software_release.version.patch_level = 0
+        return response

--- a/spot_wrapper/testing/mocks/robot_state.py
+++ b/spot_wrapper/testing/mocks/robot_state.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import typing
+
+import grpc
+from bosdyn.api.robot_state_pb2 import (
+    HardwareConfiguration,
+    RobotHardwareConfigurationRequest,
+    RobotHardwareConfigurationResponse,
+    RobotLinkModelRequest,
+    RobotLinkModelResponse,
+    RobotMetrics,
+    RobotMetricsRequest,
+    RobotMetricsResponse,
+    RobotState,
+    RobotStateRequest,
+    RobotStateResponse,
+)
+from bosdyn.api.robot_state_service_pb2_grpc import RobotStateServiceServicer
+
+
+class MockRobotStateService(RobotStateServiceServicer):
+    """
+    A mock Spot robot state service.
+
+    It exposes robot state, metrics, and hardware configuration to be modified by the user.
+    """
+
+    def __init__(self, **kwargs: typing.Any) -> None:
+        super().__init__(**kwargs)
+        self.robot_state = RobotState()
+        self.robot_metrics = RobotMetrics()
+        self.hardware_configuration = HardwareConfiguration()
+
+    def GetRobotState(
+        self, request: RobotStateRequest, context: grpc.ServicerContext
+    ) -> RobotStateResponse:
+        response = RobotStateResponse()
+        response.robot_state.CopyFrom(self.robot_state)
+        return response
+
+    def GetRobotMetrics(
+        self, request: RobotMetricsRequest, context: grpc.ServicerContext
+    ) -> RobotMetricsResponse:
+        response = RobotMetricsResponse()
+        response.robot_metrics.CopyFrom(self.robot_metrics)
+        return response
+
+    def GetRobotHardwareConfiguration(
+        self, request: RobotHardwareConfigurationRequest, context: grpc.ServicerContext
+    ) -> RobotHardwareConfigurationResponse:
+        response = RobotHardwareConfigurationResponse()
+        response.hardware_configuration.CopyFrom(self.hardware_configuration)
+        return response
+
+    def GetRobotLinkModel(
+        self, request: RobotLinkModelRequest, context: grpc.ServicerContext
+    ) -> RobotLinkModelResponse:
+        response = RobotLinkModelResponse()
+        response.link_model.filename = ""
+        return response

--- a/spot_wrapper/testing/mocks/time_sync.py
+++ b/spot_wrapper/testing/mocks/time_sync.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import grpc
+from bosdyn.api.time_sync_pb2 import (
+    TimeSyncState,
+    TimeSyncUpdateRequest,
+    TimeSyncUpdateResponse,
+)
+from bosdyn.api.time_sync_service_pb2_grpc import TimeSyncServiceServicer
+
+
+class MockTimeSyncService(TimeSyncServiceServicer):
+    """
+    A mock Spot time sync service.
+
+    Always perfect clock synchronization.
+    """
+
+    def TimeSyncUpdate(
+        self, request: TimeSyncUpdateRequest, context: grpc.ServicerContext
+    ) -> TimeSyncUpdateResponse:
+        response = TimeSyncUpdateResponse()
+        response.state.status = TimeSyncState.STATUS_OK
+        response.state.best_estimate.clock_skew.seconds = 0
+        response.state.best_estimate.clock_skew.nanos = 0
+        response.clock_identifier = request.clock_identifier or "mock-clock"
+        return response

--- a/spot_wrapper/tests/test_wrapper.py
+++ b/spot_wrapper/tests/test_wrapper.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+
+import logging
+
+import grpc
+import pytest
+from bosdyn.api.manipulation_api_pb2 import (
+    ManipulationApiRequest,
+    ManipulationApiResponse,
+)
+from bosdyn.api.power_pb2 import (
+    PowerCommandRequest,
+    PowerCommandResponse,
+    PowerCommandStatus,
+)
+from bosdyn.api.robot_command_pb2 import RobotCommandResponse
+from bosdyn.api.robot_state_pb2 import PowerState
+
+import spot_wrapper.testing
+from spot_wrapper.testing.fixtures import SpotFixture
+from spot_wrapper.testing.mocks import MockSpot
+from spot_wrapper.wrapper import SpotWrapper
+
+
+@spot_wrapper.testing.fixture(ids=["with_arm", "without_arm"], params=[True, False])
+class simple_spot(MockSpot):
+    # Inheriting from spot_wrapper.testing.mocks.MockSpot
+    # takes care of providing enough dummy base services
+    # for SpotWrapper instantiation to be possible.
+
+    def __init__(self, request) -> None:
+        # Fixture initialization can request other fixtures.
+        super().__init__()
+        if request.param:
+            manipulator_state = self.robot_state.manipulator_state
+            manipulator_state.is_gripper_holding_item = True
+
+    def PowerCommand(
+        self, request: PowerCommandRequest, context: grpc.ServicerContext
+    ) -> PowerCommandResponse:
+        # Provide custom bosdyn.api.PowerService/PowerCommand implementation.
+        response = PowerCommandResponse()
+        power_state = self.robot_state.power_state
+        if request.request == PowerCommandRequest.Request.REQUEST_ON_MOTORS:
+            power_state.motor_power_state = (
+                PowerState.MotorPowerState.MOTOR_POWER_STATE_ON
+            )
+            response.status = PowerCommandStatus.STATUS_SUCCESS
+        elif request.request == PowerCommandRequest.Request.REQUEST_OFF_MOTORS:
+            power_state.motor_power_state = (
+                PowerState.MotorPowerState.MOTOR_POWER_STATE_OFF
+            )
+            response.status = PowerCommandStatus.STATUS_SUCCESS
+        else:
+            response.status = PowerCommandStatus.STATUS_INTERNAL_ERROR
+        return response
+
+
+@pytest.fixture
+def simple_spot_wrapper(simple_spot: SpotFixture) -> SpotWrapper:
+    # Use fixture address and port for wrapper.
+    return SpotWrapper(
+        username="spot",
+        password="spot",
+        hostname=simple_spot.address,
+        port=simple_spot.port,
+        robot_name=simple_spot.api.name,
+        logger=logging.getLogger("spot"),
+    )
+
+
+def test_wrapper_setup(
+    simple_spot: SpotFixture, simple_spot_wrapper: SpotWrapper
+) -> None:
+    # spot_wrapper.testing.mocks.MockSpot dummy services enable basic usage.
+    assert simple_spot_wrapper.is_valid
+
+    ok, message = simple_spot_wrapper.claim()
+    assert ok, message
+
+    assert simple_spot_wrapper.id is not None
+    assert simple_spot_wrapper.id.nickname == simple_spot.api.name
+
+    if simple_spot_wrapper.has_arm():
+        # bosdyn.api.ManipulationApiService/ManipulationApi implementation
+        # is mocked (as spot_wrapper.testing.mocks.MockSpot is automatically
+        # specified), so we provide a response in advance.
+        request = ManipulationApiRequest()
+        request.pick_object.frame_name = "gripper"
+        request.pick_object.object_rt_frame.x = 1.0
+
+        response = ManipulationApiResponse()
+        response.manipulation_cmd_id = 1
+        simple_spot.api.ManipulationApi.future.returns(response)
+
+        ok, message, command_id = simple_spot_wrapper.manipulation_command(request)
+        assert ok and response.manipulation_cmd_id == command_id, message
+
+    # Power toggling relies on a combination of
+    assert not simple_spot_wrapper.check_is_powered_on()
+    assert simple_spot_wrapper.toggle_power(True)
+
+    # bosdyn.api.RobotCommandService/RobotCommand implementation
+    # is mocked (as spot_wrapper.testing.mocks.MockSpot is
+    # automatically specified), so we provide a response in
+    # advance.
+    response = RobotCommandResponse()
+    response.status = RobotCommandResponse.Status.STATUS_OK
+    simple_spot.api.RobotCommand.future.returns(response)
+    ok, message = simple_spot_wrapper.sit()
+    assert ok, message

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -373,6 +373,7 @@ class SpotWrapper:
         hostname: str,
         robot_name: str,
         logger: logging.Logger,
+        port: typing.Optional[int] = None,
         start_estop: bool = True,
         estop_timeout: float = 9.0,
         rates: typing.Optional[typing.Dict[str, float]] = None,
@@ -442,6 +443,8 @@ class SpotWrapper:
         self._sdk.register_service_client(ChoreographyClient)
         self._logger.info("Initialising robot at {}".format(self._hostname))
         self._robot = self._sdk.create_robot(self._hostname)
+        if port is not None:
+            self._robot.update_secure_channel_port(port)
 
         authenticated = False
         if self._payload_credentials_file:


### PR DESCRIPTION
This PR introduces `pytest` compatible machinery to aid in testing `spot_wrapper`, `spot_ros2`, and beyond.