### PR TITLE
Spot CAM stuck in infinite loop when setting PTZ position

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -795,10 +795,10 @@ class PTZWrapper:
                 self._get_ptz_description(ptz_name)
             )
             while (
-                datetime.datetime.now() - start_time < datetime.timedelta(seconds=3)
-                or not math.isclose(current_position.pan, pan, abs_tol=1)
-                or not math.isclose(current_position.tilt, tilt, abs_tol=1)
-                or not math.isclose(current_position.zoom, zoom, abs_tol=0.5)
+                (not math.isclose(current_position.pan.value, pan, abs_tol=1)
+                or not math.isclose(current_position.tilt.value, tilt, abs_tol=1)
+                or not math.isclose(current_position.zoom.value, zoom, abs_tol=0.5))
+                and datetime.datetime.now() - start_time < datetime.timedelta(seconds=3)
             ):
                 current_position = self.client.get_ptz_position(
                     self._get_ptz_description(ptz_name)

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -795,9 +795,9 @@ class PTZWrapper:
                 self._get_ptz_description(ptz_name)
             )
             while (
-                (not math.isclose(current_position.pan.value, pan, abs_tol=1)
-                or not math.isclose(current_position.tilt.value, tilt, abs_tol=1)
-                or not math.isclose(current_position.zoom.value, zoom, abs_tol=0.5))
+                not (math.isclose(current_position.pan.value, pan, abs_tol=1)
+                and math.isclose(current_position.tilt.value, tilt, abs_tol=1)
+                and math.isclose(current_position.zoom.value, zoom, abs_tol=0.5))
                 and datetime.datetime.now() - start_time < datetime.timedelta(seconds=3)
             ):
                 current_position = self.client.get_ptz_position(

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -794,12 +794,11 @@ class PTZWrapper:
             current_position = self.client.get_ptz_position(
                 self._get_ptz_description(ptz_name)
             )
-            while (
-                not (math.isclose(current_position.pan.value, pan, abs_tol=1)
+            while not (
+                math.isclose(current_position.pan.value, pan, abs_tol=1)
                 and math.isclose(current_position.tilt.value, tilt, abs_tol=1)
-                and math.isclose(current_position.zoom.value, zoom, abs_tol=0.5))
-                and datetime.datetime.now() - start_time < datetime.timedelta(seconds=3)
-            ):
+                and math.isclose(current_position.zoom.value, zoom, abs_tol=0.5)
+            ) and datetime.datetime.now() - start_time < datetime.timedelta(seconds=3):
                 current_position = self.client.get_ptz_position(
                     self._get_ptz_description(ptz_name)
                 )


### PR DESCRIPTION
On the current `main` branch (commit 0c5e3c59d8658e6c15604a4626819031d5be7588) **`set_ptz_position`** with **`blocking`** set to **`True`** might result in the Spot CAM (tested in a Spot CAM+IR with [v3.3.0](https://bostondynamics.my.site.com/SupportCenter/s/article/Spot-CAM-3-x-Release-Notes)) never returning due to an incorrect implementation of the timeout:

https://github.com/bdaiinstitute/spot_wrapper/blob/0c5e3c59d8658e6c15604a4626819031d5be7588/spot_wrapper/cam_wrapper.py#L797-L802

If either `pan`, `tilt` or `zoom` do not converge, the code will be stuck in an infinite loop.

Furthermore the members of `current_position`, at least in my version of [`bosdyn.client.spot_cam.ptz.PtzClient`](https://dev.bostondynamics.com/_modules/bosdyn/client/spot_cam/ptz) (`3.3.2`), are all [**Google Protobuf `FloatValue`s**](https://googleapis.dev/python/protobuf/latest/google/protobuf/wrappers_pb2.html) and as a result I have to access their values with `.value` when doing comparisons. Not sure if this has always been the case as I am pretty sure that we had the same code running without any issues on `3.2.3`.

So the correct while loop condition that works for me is:

```python
while (
  (not math.isclose(current_position.pan.value, pan, abs_tol=1)
  or not math.isclose(current_position.tilt.value, tilt, abs_tol=1)
  or not math.isclose(current_position.zoom.value, zoom, abs_tol=0.5))
  and datetime.datetime.now() - start_time < datetime.timedelta(seconds=3)
)
```