### PR TITLE
[SW-720] Update requirements.txt for newest spot sdk release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-bosdyn-core==3.3.2
-bosdyn-choreography-client==3.3.2
-bosdyn-choreography-protos==3.3.2
-bosdyn-client==3.3.2
-bosdyn-mission==3.3.2
-bosdyn-api==3.3.2
+bosdyn-core==4.0.0
+bosdyn-choreography-client==4.0.0
+bosdyn-client==4.0.0
+bosdyn-mission==4.0.0
+bosdyn-api==4.0.0
 protobuf==4.22.1
 setuptools==59.6.0
 pytest==7.3.1


### PR DESCRIPTION
This adds updates for spot sdk 4.0.0. According to the [release notes](https://dev.bostondynamics.com/docs/release_notes), `bosdyn-choreography-protos` can be deleted as it is moved into `bosdyn-api`.