### PR TITLE
[SW-743] Add mutate_world_objects functionality to spot_wrapper

### DIFF
--- a/spot_wrapper/spot_world_objects.py
+++ b/spot_wrapper/spot_world_objects.py
@@ -98,5 +98,5 @@ class SpotWorldObjects:
         """
         return self._world_objects_client.list_world_objects(object_types, time_start_point)
 
-    def mutate_world_object(self, request: MutateWorldObjectRequest) -> MutateWorldObjectResponse:
+    def mutate_world_objects(self, request: MutateWorldObjectRequest) -> MutateWorldObjectResponse:
         return self._world_objects_client.mutate_world_objects(request)

--- a/spot_wrapper/spot_world_objects.py
+++ b/spot_wrapper/spot_world_objects.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import logging
 import typing
 
-from bosdyn.api.world_object_pb2 import ListWorldObjectResponse, WorldObjectType, MutateWorldObjectRequest, MutateWorldObjectResponse
+from bosdyn.api.world_object_pb2 import (
+    ListWorldObjectResponse,
+    MutateWorldObjectRequest,
+    MutateWorldObjectResponse,
+    WorldObjectType,
+)
 from bosdyn.client.async_tasks import AsyncPeriodicQuery
 from bosdyn.client.common import FutureWrapper
-from bosdyn.client.world_object import WorldObjectClient, send_add_mutation_requests
+from bosdyn.client.world_object import WorldObjectClient
 
 
 class AsyncWorldObjects(AsyncPeriodicQuery):
@@ -92,6 +97,6 @@ class SpotWorldObjects:
 
         """
         return self._world_objects_client.list_world_objects(object_types, time_start_point)
-    
-    def client_mutate_world_object(self, request: MutateWorldObjectRequest) -> MutateWorldObjectResponse:
+
+    def mutate_world_object(self, request: MutateWorldObjectRequest) -> MutateWorldObjectResponse:
         return self._world_objects_client.mutate_world_objects(request)

--- a/spot_wrapper/spot_world_objects.py
+++ b/spot_wrapper/spot_world_objects.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 import typing
 
-from bosdyn.api.world_object_pb2 import ListWorldObjectResponse, WorldObjectType
+from bosdyn.api.world_object_pb2 import ListWorldObjectResponse, WorldObjectType, MutateWorldObjectRequest, MutateWorldObjectResponse
 from bosdyn.client.async_tasks import AsyncPeriodicQuery
 from bosdyn.client.common import FutureWrapper
-from bosdyn.client.world_object import WorldObjectClient
+from bosdyn.client.world_object import WorldObjectClient, send_add_mutation_requests
 
 
 class AsyncWorldObjects(AsyncPeriodicQuery):
@@ -92,3 +92,6 @@ class SpotWorldObjects:
 
         """
         return self._world_objects_client.list_world_objects(object_types, time_start_point)
+    
+    def client_mutate_world_object(self, request: MutateWorldObjectRequest) -> MutateWorldObjectResponse:
+        return self._world_objects_client.mutate_world_objects(request)

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -784,6 +784,10 @@ class SpotWrapper:
     def world_objects(self) -> world_object_pb2.ListWorldObjectResponse:
         """Return most recent proto from _world_objects_task"""
         return self.spot_world_objects.async_task.proto
+    
+    # @property
+    def mutate_world_object(self, mutate_request: world_object_pb2.MutateWorldObjectRequest) -> world_object_pb2.MutateWorldObjectResponse:
+        return self._spot_world_objects.client_mutate_world_object(mutate_request)
 
     @property
     def point_clouds(self) -> typing.List[point_cloud_pb2.PointCloudResponse]:

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1478,7 +1478,7 @@ class SpotWrapper:
         else:
             return False, "Spot is not licensed for choreography", ""
 
-    def mutate_world_object(
+    def mutate_world_objects(
         self, mutate_request: world_object_pb2.MutateWorldObjectRequest
     ) -> world_object_pb2.MutateWorldObjectResponse:
-        return self._spot_world_objects.mutate_world_object(mutate_request)
+        return self._spot_world_objects.mutate_world_objects(mutate_request)

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -784,10 +784,6 @@ class SpotWrapper:
     def world_objects(self) -> world_object_pb2.ListWorldObjectResponse:
         """Return most recent proto from _world_objects_task"""
         return self.spot_world_objects.async_task.proto
-    
-    # @property
-    def mutate_world_object(self, mutate_request: world_object_pb2.MutateWorldObjectRequest) -> world_object_pb2.MutateWorldObjectResponse:
-        return self._spot_world_objects.client_mutate_world_object(mutate_request)
 
     @property
     def point_clouds(self) -> typing.List[point_cloud_pb2.PointCloudResponse]:
@@ -1481,3 +1477,8 @@ class SpotWrapper:
             return self._spot_dance.choreography_log_to_animation_file(name, fpath, has_arm, **kwargs)
         else:
             return False, "Spot is not licensed for choreography", ""
+
+    def mutate_world_object(
+        self, mutate_request: world_object_pb2.MutateWorldObjectRequest
+    ) -> world_object_pb2.MutateWorldObjectResponse:
+        return self._spot_world_objects.mutate_world_object(mutate_request)


### PR DESCRIPTION
This allows the user to mutate Spot's world objects. Specifically, it can be used to create/delete no-go regions for Spot which are implemented as new world objects. 

I have been testing this in conjunction with a [follow-up PR](https://github.com/bdaiinstitute/spot_ros2/pull/271) to integrate this into Spot ROS 2. With this implementation, Spot is successfully able to receive and respond to mutate world object requests. 