### PR TITLE
Allow repeated future outcomes in mocked gRPCs

### DIFF
--- a/spot_wrapper/testing/grpc.py
+++ b/spot_wrapper/testing/grpc.py
@@ -353,7 +353,7 @@ class DeferredRpcHandler(GeneralizedDecorator):
 
             def resolve(self, call: "DeferredRpcHandler.Call") -> bool:
                 """Resolves the given `call` using this outcome."""
-                num_repeats = float(self._num_repeats or 0)
+                num_repeats = float(self._num_repeats or 1)
                 if self._num_uses >= num_repeats:
                     return False
                 self.do_resolve(call)

--- a/spot_wrapper/tests/test_wrapper.py
+++ b/spot_wrapper/tests/test_wrapper.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
 
 import logging
-
 from typing import Iterator
 
 import grpc


### PR DESCRIPTION
Follow-up to #81. This patch should make it easier to work with blocking calls that invoke many gRPCs. 

Now, in addition to `future.returns()` and `future.fails()`, you can invoke `future.returns().repeatedly(N)` and `future.fails().repeatedly(N)` to repeat the same outcome a finite number of times and  `future.returns().forever()` and `future.fails().forever()` to repeat the same outcome indefinitely.