### PR TITLE
Bump Spot SDK version to 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bosdyn-core==4.0.0
 bosdyn-choreography-client==4.0.0
+bosdyn-choreography-protos==4.0.0
 bosdyn-client==4.0.0
 bosdyn-mission==4.0.0
 bosdyn-api==4.0.0


### PR DESCRIPTION
Precisely what the title says. This patch bumps the versions of Spot SDK specific Python requirements.