### PR TITLE
Remove choreography protos, since it is an empty package in 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 bosdyn-core==4.0.0
 bosdyn-choreography-client==4.0.0
-bosdyn-choreography-protos==4.0.0
 bosdyn-client==4.0.0
 bosdyn-mission==4.0.0
 bosdyn-api==4.0.0


### PR DESCRIPTION
From the [4.0.0 release notes](https://dev.bostondynamics.com/docs/release_notes):

`The protos in the bosdyn-choreography-protos package have been moved into bosdyn-api; bosdyn-choreography-protos is now an empty package that just depends on bosdyn-api.`