### PR TITLE
[SW-758] Make SpotCamWrapper authenticate using the same robot instance as SpotWrapper

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -32,7 +32,7 @@ from bosdyn.client.spot_cam.streamquality import StreamQualityClient
 from PIL import Image
 
 from spot_wrapper.cam_webrtc_client import WebRTCClient
-from spot_wrapper.wrapper import SpotWrapper
+# from spot_wrapper.wrapper import SpotWrapper
 
 
 class LightingWrapper:
@@ -491,11 +491,9 @@ class MediaLogWrapper:
         filename: str,
         extension: str,
         camera: typing.Optional[SpotCamCamera] = None,
-    ) -> str:
+        ) -> str:
         """
         Build a filename from a base name. Returns files of the form basefilename_cameraname_iso_date
-
-
         Args:
             logpoint: Build a filename for this logpoint
             filename: Base filename to use
@@ -895,7 +893,7 @@ class ImageStreamWrapper:
 
 
 class SpotCamWrapper:
-    def __init__(self, hostname, username, password, logger, port: typing.Optional[int] = None):
+    def __init__(self, hostname, username, password, robot, logger, port: typing.Optional[int] = None):
         self._hostname = hostname
         self._username = username
         self._password = password
@@ -905,10 +903,9 @@ class SpotCamWrapper:
         self.sdk = bosdyn.client.create_standard_sdk("Spot CAM Client")
         spot_cam.register_all_service_clients(self.sdk)
 
-        self.robot = self.sdk.create_robot(self._hostname)
+        self.robot = robot
         if port is not None:
             self.robot.update_secure_channel_port(port)
-        SpotWrapper.authenticate(self.robot, self._username, self._password, self._logger)
 
         self.payload_client: PayloadClient = self.robot.ensure_client(PayloadClient.default_service_name)
         self.payload_details = None

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -893,15 +893,15 @@ class ImageStreamWrapper:
 
 
 class SpotCamWrapper:
-    def __init__(self, hostname, username, password, logger, robot, sdk, port: typing.Optional[int] = None):
+    def __init__(self, hostname, username, password, logger, robot, port: typing.Optional[int] = None):
         self._hostname = hostname
         self._username = username
         self._password = password
         self._logger = logger
 
         # Create robot object and authenticate.
-        self.sdk = sdk
-        spot_cam.register_all_service_clients(self.sdk)
+        # self.sdk = sdk
+        # spot_cam.register_all_service_clients(self.sdk)
 
         self.robot = robot
         if port is not None:
@@ -920,15 +920,18 @@ class SpotCamWrapper:
                 "admin interface"
             )
 
-        self.lighting = LightingWrapper(self.robot, self._logger)
-        self.power = PowerWrapper(self.robot, self._logger)
-        self.compositor = CompositorWrapper(self.robot, self._logger)
-        self.image = ImageStreamWrapper(self._hostname, self.robot, self._logger)
-        self.health = HealthWrapper(self.robot, self._logger)
-        self.audio = AudioWrapper(self.robot, self._logger)
-        self.stream_quality = StreamQualityWrapper(self.robot, self._logger)
-        self.media_log = MediaLogWrapper(self.robot, self._logger)
-        self.ptz = PTZWrapper(self.robot, self._logger)
+        try:
+            self.lighting = LightingWrapper(self.robot, self._logger)
+            self.power = PowerWrapper(self.robot, self._logger)
+            self.compositor = CompositorWrapper(self.robot, self._logger)
+            self.image = ImageStreamWrapper(self._hostname, self.robot, self._logger)
+            self.health = HealthWrapper(self.robot, self._logger)
+            self.audio = AudioWrapper(self.robot, self._logger)
+            self.stream_quality = StreamQualityWrapper(self.robot, self._logger)
+            self.media_log = MediaLogWrapper(self.robot, self._logger)
+            self.ptz = PTZWrapper(self.robot, self._logger)
+        except Exception as e:
+            self._logger.warn(f"Error setting up spot cam wrapper components: {str(e)}")
 
         self._logger.info("Finished setting up spot cam wrapper components")
 

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -893,14 +893,14 @@ class ImageStreamWrapper:
 
 
 class SpotCamWrapper:
-    def __init__(self, hostname, username, password, logger, robot, port: typing.Optional[int] = None):
+    def __init__(self, hostname, username, password, logger, robot, sdk, port: typing.Optional[int] = None):
         self._hostname = hostname
         self._username = username
         self._password = password
         self._logger = logger
 
         # Create robot object and authenticate.
-        self.sdk = bosdyn.client.create_standard_sdk("Spot CAM Client")
+        self.sdk = sdk
         spot_cam.register_all_service_clients(self.sdk)
 
         self.robot = robot

--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -893,7 +893,7 @@ class ImageStreamWrapper:
 
 
 class SpotCamWrapper:
-    def __init__(self, hostname, username, password, robot, logger, port: typing.Optional[int] = None):
+    def __init__(self, hostname, username, password, logger, robot, port: typing.Optional[int] = None):
         self._hostname = hostname
         self._username = username
         self._password = password

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -54,6 +54,7 @@ from bosdyn.client.robot_state import RobotStateClient
 from bosdyn.client.spot_check import SpotCheckClient
 from bosdyn.client.time_sync import TimeSyncEndpoint
 from bosdyn.client.world_object import WorldObjectClient
+from bosdyn.client import spot_cam
 from bosdyn.geometry import EulerZXY
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -597,8 +598,9 @@ class SpotWrapper:
         Initializes the spot camera wrapper
         """
         self.authenticate(self._robot, self._username, self._password, cam_logger)
+        spot_cam.register_all_service_clients(self._sdk)
         spot_cam_wrapper = SpotCamWrapper(self._hostname, self._username, self._password, cam_logger, 
-                                          self._robot, self._sdk)
+                                          self._robot)
         return spot_cam_wrapper
 
     def decorate_functions(self):

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -596,8 +596,8 @@ class SpotWrapper:
         """
         Initializes the spot camera wrapper
         """
-        spot_cam_wrapper = SpotCamWrapper(self._hostname, self._username, self._password, self._robot, cam_logger)
         self.authenticate(self._robot, self._username, self._password, cam_logger)
+        spot_cam_wrapper = SpotCamWrapper(self._hostname, self._username, self._password, cam_logger, self._robot)
         return spot_cam_wrapper
 
     def decorate_functions(self):

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -597,7 +597,8 @@ class SpotWrapper:
         Initializes the spot camera wrapper
         """
         self.authenticate(self._robot, self._username, self._password, cam_logger)
-        spot_cam_wrapper = SpotCamWrapper(self._hostname, self._username, self._password, cam_logger, self._robot)
+        spot_cam_wrapper = SpotCamWrapper(self._hostname, self._username, self._password, cam_logger, 
+                                          self._robot, self._sdk)
         return spot_cam_wrapper
 
     def decorate_functions(self):

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -65,6 +65,7 @@ from .spot_eap import SpotEAP
 from .spot_graph_nav import SpotGraphNav
 from .spot_images import SpotImages
 from .spot_world_objects import SpotWorldObjects
+from .cam_wrapper import SpotCamWrapper
 from .wrapper_helpers import ClaimAndPowerDecorator, RobotCommandData, RobotState
 
 SPOT_CLIENT_NAME = "ros_spot"
@@ -590,6 +591,14 @@ class SpotWrapper:
 
         self._robot_id = None
         self._lease = None
+    
+    def init_camera_wrapper(self, cam_logger) -> SpotCamWrapper:
+        """
+        Initializes the spot camera wrapper
+        """
+        spot_cam_wrapper = SpotCamWrapper(self._hostname, self._username, self._password, self._robot, cam_logger)
+        self.authenticate(self._robot, self._username, self._password, cam_logger)
+        return spot_cam_wrapper
 
     def decorate_functions(self):
         """


### PR DESCRIPTION
modified  so that `SpotCamWrapper` will use the same instance of robot as `SpotWrapper`

Linked to https://github.com/bdaiinstitute/spot_ros2/pull/339

Currently having some errors during testing