### PR TITLE
Added possibility to directly control the arm using an ArmVelocityCommand

### DIFF
--- a/spot_wrapper/spot_arm.py
+++ b/spot_wrapper/spot_arm.py
@@ -537,7 +537,6 @@ class SpotArm:
                 )
 
         except Exception as e:
-            print(e)
             return (
                 False,
                 f"An error occured while trying to move arm\n Exception: {e}",

--- a/spot_wrapper/spot_arm.py
+++ b/spot_wrapper/spot_arm.py
@@ -526,6 +526,7 @@ class SpotArm:
                     cylindrical_velocity=arm_velocity_command.cylindrical_velocity,
                     angular_velocity_of_hand_rt_odom_in_hand=arm_velocity_command.angular_velocity_of_hand_rt_odom_in_hand,
                     cartesian_velocity=arm_velocity_command.cartesian_velocity,
+                    maximum_acceleration = arm_velocity_command.maximum_acceleration,
                     end_time=end_time,
                 )
 


### PR DESCRIPTION
## Change Overview

Added the ability to set a Velocity command for the arm. This enables a user to have direct translational and rotational  control of the TCP movement using a controller or any other input device. The corresponding [PR](https://github.com/bdaiinstitute/spot_ros2/pull/366) on the driver Repo provides a topic interface to send the corresponding movement command. 
The angular and Cartesian velocity were thoroughly tested during operation on our spot. For the cylindrical velocity I performed some basic tests but didn't evaluate over hours as the other two input methods since I don't really use them in this reference frame.

## Testing Done
    - [x] tested that these new functionality work on robot

