### PR TITLE
Add functionality to set the grasp and carry overrides

### DIFF
--- a/spot_wrapper/spot_arm.py
+++ b/spot_wrapper/spot_arm.py
@@ -614,8 +614,11 @@ class SpotArm:
         except Exception as e:
             return False, f"An error occured while trying to grasp from pose {e}"
 
-    def override_grasp_or_carry(self, grasp_override: manipulation_api_pb2.ApiGraspOverride.Override,
-                                carry_override: ManipulatorState.CarryState) -> typing.Tuple[bool, str]:
+    def override_grasp_or_carry(
+        self,
+        grasp_override: manipulation_api_pb2.ApiGraspOverride.Override,
+        carry_override: ManipulatorState.CarryState,
+    ) -> typing.Tuple[bool, str]:
         """
         Override the robot's grasp and/or carry state.
 


### PR DESCRIPTION
This adds a function that lets us override grasp state (whether or not the robot thinks it's carrying something) and/or carry state (what the robot will do on stow) through the spot wrapper.  A companion request will be open in spot_ros2 to wrap this in a ros2 service.

**Testing Done**
All testing done by calling the ROS2 service from the command line and then checking the manipulation state topic:
- [x] Only grasp override set in request message
- [x] Only carry override set in the request message
- [x] Grasp state override and carry state explicitly set to 0 in request message
- [x] Carry override and grasp override set in request message
- [x] Carry override set and grasp override set to NOT_HOLDING (correctly returns a False and an error message)

I also spot checked that the tablet Empty/Grasping icon changed appropriately and checked the hijack behavior to see the carry state effects.