### PR TITLE
Allow `SpotCamWrapper` port and certs configuration

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import enum
+import logging
 import math
 import os.path
 import pathlib
@@ -895,14 +896,22 @@ class ImageStreamWrapper:
 
 
 class SpotCamWrapper:
-    def __init__(self, hostname, username, password, logger, port: typing.Optional[int] = None):
+    def __init__(
+        self,
+        hostname: str,
+        username: str,
+        password: str,
+        logger: logging.Logger,
+        port: typing.Optional[int] = None,
+        cert_resource_glob: typing.Optional[str] = None,
+    ) -> None:
         self._hostname = hostname
         self._username = username
         self._password = password
         self._logger = logger
 
         # Create robot object and authenticate.
-        self.sdk = bosdyn.client.create_standard_sdk("Spot CAM Client")
+        self.sdk = bosdyn.client.create_standard_sdk("Spot CAM Client", cert_resource_glob=cert_resource_glob)
         spot_cam.register_all_service_clients(self.sdk)
 
         self.robot = self.sdk.create_robot(self._hostname)


### PR DESCRIPTION
Follow-up to #103. This patch enables `SpotCamWrapper` to work with custom port and SSL certificates.