### PR TITLE
Extend response header autocompletion support

### DIFF
--- a/spot_wrapper/testing/grpc.py
+++ b/spot_wrapper/testing/grpc.py
@@ -289,7 +289,7 @@ class AutoCompletingUnaryStreamRpcHandler(ThinDecorator):
 
 
 class AutoCompletingStreamStreamRpcHandler(ThinDecorator):
-    """A decorator for stream-stream gRPC handlers autocompletes response headers.
+    """A decorator for stream-stream gRPC handlers that autocompletes response headers.
 
     The last request chunk header will be used to complete the response header.
     """

--- a/spot_wrapper/testing/grpc.py
+++ b/spot_wrapper/testing/grpc.py
@@ -12,8 +12,9 @@ import typing
 from abc import ABC, abstractmethod
 
 import grpc
+from bosdyn.api.header_pb2 import CommonError
 
-from spot_wrapper.testing.helpers import GeneralizedDecorator
+from spot_wrapper.testing.helpers import ThinDecorator
 
 
 def implemented(function: typing.Callable) -> bool:
@@ -94,10 +95,12 @@ class AutoServicer(object):
         autospec: if true, deferred handlers will be used in place for every
         non-implemented method handler.
         autotrack: if true, tracking handlers will decorate every method handler.
+        autocomplete: if true, autocompleting handlers will decorate every method handler.
     """
 
     autospec = False
     autotrack = False
+    autocomplete = False
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
@@ -112,6 +115,8 @@ class AutoServicer(object):
                         self.needs_shutdown.append(underlying_callable)
                     if self.autotrack:
                         underlying_callable = TrackingStreamStreamRpcHandler(underlying_callable)
+                    if self.autocomplete:
+                        underlying_callable = AutoCompletingStreamStreamRpcHandler(underlying_callable)
                     if underlying_callable is not handler.stream_stream:
                         setattr(self, unqualified_name, underlying_callable)
                 else:
@@ -122,6 +127,8 @@ class AutoServicer(object):
                         self.needs_shutdown.append(underlying_callable)
                     if self.autotrack:
                         underlying_callable = TrackingUnaryStreamRpcHandler(underlying_callable)
+                    if self.autocomplete:
+                        underlying_callable = AutoCompletingUnaryStreamRpcHandler(underlying_callable)
                     if underlying_callable is not handler.unary_stream:
                         setattr(self, unqualified_name, underlying_callable)
             else:
@@ -133,6 +140,8 @@ class AutoServicer(object):
                         self.needs_shutdown.append(underlying_callable)
                     if self.autotrack:
                         underlying_callable = TrackingStreamUnaryRpcHandler(underlying_callable)
+                    if self.autocomplete:
+                        underlying_callable = AutoCompletingStreamUnaryRpcHandler(underlying_callable)
                     if underlying_callable is not handler.stream_unary:
                         setattr(self, unqualified_name, underlying_callable)
                 else:
@@ -143,6 +152,8 @@ class AutoServicer(object):
                         self.needs_shutdown.append(underlying_callable)
                     if self.autotrack:
                         underlying_callable = TrackingUnaryUnaryRpcHandler(underlying_callable)
+                    if self.autocomplete:
+                        underlying_callable = AutoCompletingUnaryUnaryRpcHandler(underlying_callable)
                     if underlying_callable is not handler.unary_unary:
                         setattr(self, unqualified_name, underlying_callable)
 
@@ -167,7 +178,7 @@ class AutoServicer(object):
             obj.shutdown()
 
 
-class TrackingUnaryUnaryRpcHandler(GeneralizedDecorator):
+class TrackingUnaryUnaryRpcHandler(ThinDecorator):
     """A decorator for unary-unary gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -183,7 +194,7 @@ class TrackingUnaryUnaryRpcHandler(GeneralizedDecorator):
             self.num_calls += 1
 
 
-class TrackingStreamUnaryRpcHandler(GeneralizedDecorator):
+class TrackingStreamUnaryRpcHandler(ThinDecorator):
     """A decorator for stream-unary gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -201,7 +212,7 @@ class TrackingStreamUnaryRpcHandler(GeneralizedDecorator):
             self.num_calls += 1
 
 
-class TrackingUnaryStreamRpcHandler(GeneralizedDecorator):
+class TrackingUnaryStreamRpcHandler(ThinDecorator):
     """A decorator for unary-stream gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -217,7 +228,7 @@ class TrackingUnaryStreamRpcHandler(GeneralizedDecorator):
             self.num_calls += 1
 
 
-class TrackingStreamStreamRpcHandler(GeneralizedDecorator):
+class TrackingStreamStreamRpcHandler(ThinDecorator):
     """A decorator for stream-stream gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -235,7 +246,62 @@ class TrackingStreamStreamRpcHandler(GeneralizedDecorator):
             self.num_calls += 1
 
 
-class DeferredRpcHandler(GeneralizedDecorator):
+def fill_response_header(request: typing.Any, response: typing.Any) -> bool:
+    """Fill response header if any when missing."""
+    if not hasattr(response, "header"):
+        return False
+    if hasattr(request, "header"):
+        response.header.request_header.CopyFrom(request.header)
+        response.header.request_received_timestamp.CopyFrom(request.header.request_timestamp)
+    response.header.error.code = response.header.error.code or CommonError.CODE_OK
+    return True
+
+
+class AutoCompletingUnaryUnaryRpcHandler(ThinDecorator):
+    """A decorator for unary-unary gRPC handlers that autocompletes response headers."""
+
+    def __call__(self, request: typing.Any, context: grpc.ServicerContext) -> typing.Any:
+        response = self.__wrapped__(request, context)
+        fill_response_header(request, response)
+        return response
+
+
+class AutoCompletingStreamUnaryRpcHandler(ThinDecorator):
+    """A decorator for stream-unary gRPC handlers that autocompletes response headers.
+
+    The last request chunk header will be used to complete the response header.
+    """
+
+    def __call__(self, request_iterator: typing.Iterator, context: grpc.ServicerContext) -> typing.Any:
+        *head_requests, tail_request = request_iterator
+        response = self.__wrapped__(iter([*head_requests, tail_request]), context)
+        fill_response_header(tail_request, response)
+        return response
+
+
+class AutoCompletingUnaryStreamRpcHandler(ThinDecorator):
+    """A decorator for unary-stream gRPC handlers that autocompletes response headers."""
+
+    def __call__(self, request: typing.Any, context: grpc.ServicerContext) -> typing.Iterator:
+        for response in self.__wrapped__(request, context):
+            fill_response_header(request, response)
+            yield response
+
+
+class AutoCompletingStreamStreamRpcHandler(ThinDecorator):
+    """A decorator for stream-stream gRPC handlers autocompletes response headers.
+
+    The last request chunk header will be used to complete the response header.
+    """
+
+    def __call__(self, request_iterator: typing.Iterator, context: grpc.ServicerContext) -> typing.Iterator:
+        *head_requests, tail_request = request_iterator
+        for response in self.__wrapped__(iter([*head_requests, tail_request]), context):
+            fill_response_header(tail_request, response)
+            yield response
+
+
+class DeferredRpcHandler(ThinDecorator):
     """
     A gRPC handler that decouples invocation and computation execution paths.
 

--- a/spot_wrapper/testing/grpc.py
+++ b/spot_wrapper/testing/grpc.py
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 import grpc
 from bosdyn.api.header_pb2 import CommonError
 
-from spot_wrapper.testing.helpers import ThinDecorator
+from spot_wrapper.testing.helpers import ForwardingWrapper
 
 
 def implemented(function: typing.Callable) -> bool:
@@ -178,7 +178,7 @@ class AutoServicer(object):
             obj.shutdown()
 
 
-class TrackingUnaryUnaryRpcHandler(ThinDecorator):
+class TrackingUnaryUnaryRpcHandler(ForwardingWrapper):
     """A decorator for unary-unary gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -194,7 +194,7 @@ class TrackingUnaryUnaryRpcHandler(ThinDecorator):
             self.num_calls += 1
 
 
-class TrackingStreamUnaryRpcHandler(ThinDecorator):
+class TrackingStreamUnaryRpcHandler(ForwardingWrapper):
     """A decorator for stream-unary gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -212,7 +212,7 @@ class TrackingStreamUnaryRpcHandler(ThinDecorator):
             self.num_calls += 1
 
 
-class TrackingUnaryStreamRpcHandler(ThinDecorator):
+class TrackingUnaryStreamRpcHandler(ForwardingWrapper):
     """A decorator for unary-stream gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -228,7 +228,7 @@ class TrackingUnaryStreamRpcHandler(ThinDecorator):
             self.num_calls += 1
 
 
-class TrackingStreamStreamRpcHandler(ThinDecorator):
+class TrackingStreamStreamRpcHandler(ForwardingWrapper):
     """A decorator for stream-stream gRPC handlers that tracks calls."""
 
     def __init__(self, handler: typing.Callable) -> None:
@@ -257,7 +257,7 @@ def fill_response_header(request: typing.Any, response: typing.Any) -> bool:
     return True
 
 
-class AutoCompletingUnaryUnaryRpcHandler(ThinDecorator):
+class AutoCompletingUnaryUnaryRpcHandler(ForwardingWrapper):
     """A decorator for unary-unary gRPC handlers that autocompletes response headers."""
 
     def __call__(self, request: typing.Any, context: grpc.ServicerContext) -> typing.Any:
@@ -266,7 +266,7 @@ class AutoCompletingUnaryUnaryRpcHandler(ThinDecorator):
         return response
 
 
-class AutoCompletingStreamUnaryRpcHandler(ThinDecorator):
+class AutoCompletingStreamUnaryRpcHandler(ForwardingWrapper):
     """A decorator for stream-unary gRPC handlers that autocompletes response headers.
 
     The last request chunk header will be used to complete the response header.
@@ -279,7 +279,7 @@ class AutoCompletingStreamUnaryRpcHandler(ThinDecorator):
         return response
 
 
-class AutoCompletingUnaryStreamRpcHandler(ThinDecorator):
+class AutoCompletingUnaryStreamRpcHandler(ForwardingWrapper):
     """A decorator for unary-stream gRPC handlers that autocompletes response headers."""
 
     def __call__(self, request: typing.Any, context: grpc.ServicerContext) -> typing.Iterator:
@@ -288,7 +288,7 @@ class AutoCompletingUnaryStreamRpcHandler(ThinDecorator):
             yield response
 
 
-class AutoCompletingStreamStreamRpcHandler(ThinDecorator):
+class AutoCompletingStreamStreamRpcHandler(ForwardingWrapper):
     """A decorator for stream-stream gRPC handlers that autocompletes response headers.
 
     The last request chunk header will be used to complete the response header.
@@ -301,7 +301,7 @@ class AutoCompletingStreamStreamRpcHandler(ThinDecorator):
             yield response
 
 
-class DeferredRpcHandler(ThinDecorator):
+class DeferredRpcHandler(ForwardingWrapper):
     """
     A gRPC handler that decouples invocation and computation execution paths.
 

--- a/spot_wrapper/testing/helpers.py
+++ b/spot_wrapper/testing/helpers.py
@@ -6,7 +6,9 @@ import typing
 from bosdyn.api.lease_pb2 import ResourceTree
 
 
-class ThinDecorator:
+class ForwardingWrapper:
+    """A `functools.wraps` equivalent that is transparent to attribute access."""
+
     __name__ = __qualname__ = __doc__ = ""
 
     __annotations__ = {}
@@ -14,7 +16,7 @@ class ThinDecorator:
     @staticmethod
     def wraps(wrapped: typing.Callable):
         def decorator(func: typing.Callable):
-            class wrapper(ThinDecorator):
+            class wrapper(ForwardingWrapper):
                 def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
                     return func(*args, **kwargs)
 

--- a/spot_wrapper/testing/mocks/__init__.py
+++ b/spot_wrapper/testing/mocks/__init__.py
@@ -162,19 +162,7 @@ class BaseMockSpot(
     """
 
     name = "mockie"
-
-    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        super().__init__(*args, **kwargs)
-        for _, handler in collect_method_handlers(self):
-            if handler.request_streaming:
-                continue
-            if handler.response_streaming:
-                continue
-            setattr(
-                self,
-                handler.unary_unary.__name__,
-                enforce_matching_headers(handler.unary_unary),
-            )
+    autocomplete = True
 
 
 class MockSpot(

--- a/spot_wrapper/testing/mocks/__init__.py
+++ b/spot_wrapper/testing/mocks/__init__.py
@@ -84,7 +84,6 @@ from bosdyn.api.time_sync_service_pb2_grpc import TimeSyncServiceServicer
 from bosdyn.api.world_object_service_pb2_grpc import WorldObjectServiceServicer
 
 from spot_wrapper.testing.grpc import AutoServicer, collect_method_handlers
-from spot_wrapper.testing.helpers import enforce_matching_headers
 from spot_wrapper.testing.mocks.auth import MockAuthService
 from spot_wrapper.testing.mocks.directory import MockDirectoryService
 from spot_wrapper.testing.mocks.estop import MockEStopService


### PR DESCRIPTION
Follow-up to #81. This patch extends the logic for response header autocompletion to gRPC services that are not unary in both request and response.