### PR TITLE
Fix `AudioWrapper.list_sounds()`

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -261,7 +261,7 @@ class AudioWrapper:
         Returns:
             List of names of available sounds
         """
-        return self.client.list_sounds()
+        return [sound.name for sound in self.client.list_sounds()]
 
     def set_volume(self, percentage):
         """


### PR DESCRIPTION
Pretty much that. `AudioWrapper.list_sounds()` implementation did not match its own contract, returning a list of `bosdyn.api.spot_cam.audio_pb2.Sound` messages instead of a list of strings.