### PR TITLE
Fix `SpotGraphNav.list_graph()` implementation.

### DIFF
--- a/spot_wrapper/spot_graph_nav.py
+++ b/spot_wrapper/spot_graph_nav.py
@@ -68,7 +68,7 @@ class SpotGraphNav:
         """
         ids, eds = self._list_graph_waypoint_and_edge_ids()
 
-        return [v for k, v in sorted(ids.items(), key=lambda id: int(id[0].replace("waypoint_", "")))]
+        return [v for _, v in sorted(ids.items(), key=lambda item: item[0])]
 
     def navigate_initial_localization(
         self,


### PR DESCRIPTION
Waypoint names may not be integers, so we enforce a lexicographic order instead.