### PR TITLE
Avoid using port 0 for `SpotCamWrapper`

### DIFF
--- a/spot_wrapper/cam_wrapper.py
+++ b/spot_wrapper/cam_wrapper.py
@@ -915,7 +915,7 @@ class SpotCamWrapper:
         spot_cam.register_all_service_clients(self.sdk)
 
         self.robot = self.sdk.create_robot(self._hostname)
-        if port is not None:
+        if port:
             self.robot.update_secure_channel_port(port)
         SpotWrapper.authenticate(self.robot, self._username, self._password, self._logger)
 


### PR DESCRIPTION
Follow-up to #81. `SpotCamWrapper` should never try to use an arbitrary, random port.