### PR TITLE
[SW-1239] Expose body_height parameter in velocity_cmd()

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1277,7 +1277,7 @@ class SpotWrapper:
         return self._mobility_params
 
     def velocity_cmd(
-        self, v_x: float, v_y: float, v_rot: float, cmd_duration: float = 0.125
+        self, v_x: float, v_y: float, v_rot: float, cmd_duration: float = 0.125, body_height: float = 0
     ) -> typing.Tuple[bool, str]:
         """
 
@@ -1295,7 +1295,9 @@ class SpotWrapper:
         """
         end_time = time.time() + cmd_duration
         response = self._robot_command(
-            RobotCommandBuilder.synchro_velocity_command(v_x=v_x, v_y=v_y, v_rot=v_rot, params=self._mobility_params),
+            RobotCommandBuilder.synchro_velocity_command(v_x=v_x, v_y=v_y, v_rot=v_rot, 
+                                                         params=self._mobility_params, 
+                                                         body_height=body_height),
             end_time_secs=end_time,
             timesync_endpoint=self._robot.time_sync.endpoint,
         )


### PR DESCRIPTION
Exposed the `body_height` parameter in the `velocity_cmd()` method to allow users to specify the height of Spot as it moves. 

EEP requested this feature to use with their new controllers. Previously, the height would reset back to a default of 0 whenever velocity commands were sent.