### PR TITLE
Handle cases when mobility command feedback does not contain a specific command status

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -206,32 +206,43 @@ class AsyncIdle(AsyncPeriodicQuery):
         if self._spot_wrapper.last_stand_command is not None:
             try:
                 response = self._client.robot_command_feedback(self._spot_wrapper.last_stand_command)
-                status = response.feedback.synchronized_feedback.mobility_command_feedback.stand_feedback.status
-                self._spot_wrapper.is_sitting = False
-                if status == basic_command_pb2.StandCommand.Feedback.STATUS_IS_STANDING:
-                    self._spot_wrapper.is_standing = True
-                    self._spot_wrapper.last_stand_command = None
-                elif status == basic_command_pb2.StandCommand.Feedback.STATUS_IN_PROGRESS:
-                    self._spot_wrapper.is_standing = False
+                command_feedback = response.feedback.synchronized_feedback.mobility_command_feedback
+                if command_feedback.status == basic_command_pb2.RobotCommandFeedbackStatus.STATUS_PROCESSING:
+                    self._spot_wrapper.is_sitting = False
+                    stand_status = command_feedback.stand_feedback.status
+                    if stand_status == basic_command_pb2.StandCommand.Feedback.STATUS_IS_STANDING:
+                        self._spot_wrapper.is_standing = True
+                        self._spot_wrapper.last_stand_command = None
+                    elif stand_status == basic_command_pb2.StandCommand.Feedback.STATUS_IN_PROGRESS:
+                        self._spot_wrapper.is_standing = False
+                    else:
+                        self._logger.warning("Stand command in unknown state")
+                        self._spot_wrapper.is_standing = False
                 else:
-                    self._logger.warning("Stand command in unknown state")
-                    self._spot_wrapper.is_standing = False
+                    self._logger.warning(f"Stand command is not being processed anymore, current status: {command_feedback.status}")
+                    self._spot_wrapper.last_stand_command = None
             except (ResponseError, RpcError) as e:
                 self._logger.error("Error when getting robot command feedback: %s", e)
                 self._spot_wrapper.last_stand_command = None
 
         if self._spot_wrapper.last_sit_command is not None:
             try:
-                self._spot_wrapper.is_standing = False
                 response = self._client.robot_command_feedback(self._spot_wrapper.last_sit_command)
-                if (
-                    response.feedback.synchronized_feedback.mobility_command_feedback.sit_feedback.status
-                    == basic_command_pb2.SitCommand.Feedback.STATUS_IS_SITTING
-                ):
-                    self._spot_wrapper.is_sitting = True
-                    self._spot_wrapper.last_sit_command = None
+                command_feedback = response.feedback.synchronized_feedback.mobility_command_feedback
+                if command_feedback.status == basic_command_pb2.RobotCommandFeedbackStatus.STATUS_PROCESSING:
+                    self._spot_wrapper.is_standing = False
+                    sit_status = command_feedback.sit_feedback.status
+                    if sit_status == basic_command_pb2.SitCommand.Feedback.STATUS_IS_SITTING:
+                        self._spot_wrapper.is_sitting = True
+                        self._spot_wrapper.last_sit_command = None
+                    elif sit_status == basic_command_pb2.SitCommand.Feedback.STATUS_IN_PROGRESS:
+                        self._spot_wrapper.is_sitting = False
+                    else:
+                        self._logger.warning("Sit command in unknown state")
+                        self._spot_wrapper.is_sitting = False
                 else:
-                    self._spot_wrapper.is_sitting = False
+                    self._logger.warning(f"Sit command is not being processed anymore, current status: {command_feedback.status}")
+                    self._spot_wrapper.last_sit_command = None
             except (ResponseError, RpcError) as e:
                 self._logger.error("Error when getting robot command feedback: %s", e)
                 self._spot_wrapper.last_sit_command = None
@@ -278,6 +289,12 @@ class AsyncIdle(AsyncPeriodicQuery):
                 self._spot_wrapper.last_trajectory_command = None
 
         self._spot_wrapper.is_moving = is_moving
+
+        # Check if the robot is currently not receiving any velocity/trajectory commands as these will override any previous sit/stand commands,
+        # and might leave the robot in an illogical state (sitting and moving at the same time).
+        if self._spot_wrapper.is_moving:
+            self._spot_wrapper.is_standing = True
+            self._spot_wrapper.is_sitting = False
 
         # We must check if any command currently has a non-None value for its id. If we don't do this, this stand
         # command can cause other commands to be interrupted before they get to start

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -219,7 +219,9 @@ class AsyncIdle(AsyncPeriodicQuery):
                         self._logger.warning("Stand command in unknown state")
                         self._spot_wrapper.is_standing = False
                 else:
-                    self._logger.warning(f"Stand command is not being processed anymore, current status: {command_feedback.status}")
+                    self._logger.warning(
+                        f"Stand command is not being processed anymore, current status: {command_feedback.status}"
+                    )
                     self._spot_wrapper.last_stand_command = None
             except (ResponseError, RpcError) as e:
                 self._logger.error("Error when getting robot command feedback: %s", e)
@@ -241,7 +243,9 @@ class AsyncIdle(AsyncPeriodicQuery):
                         self._logger.warning("Sit command in unknown state")
                         self._spot_wrapper.is_sitting = False
                 else:
-                    self._logger.warning(f"Sit command is not being processed anymore, current status: {command_feedback.status}")
+                    self._logger.warning(
+                        f"Sit command is not being processed anymore, current status: {command_feedback.status}"
+                    )
                     self._spot_wrapper.last_sit_command = None
             except (ResponseError, RpcError) as e:
                 self._logger.error("Error when getting robot command feedback: %s", e)
@@ -290,8 +294,9 @@ class AsyncIdle(AsyncPeriodicQuery):
 
         self._spot_wrapper.is_moving = is_moving
 
-        # Check if the robot is currently not receiving any velocity/trajectory commands as these will override any previous sit/stand commands,
-        # and might leave the robot in an illogical state (sitting and moving at the same time).
+        # Check if the robot is currently not receiving any velocity/trajectory commands as these will override any
+        # previous sit/stand commands, and might leave the robot in an illogical state (sitting and moving at the
+        # same time).
         if self._spot_wrapper.is_moving:
             self._spot_wrapper.is_standing = True
             self._spot_wrapper.is_sitting = False


### PR DESCRIPTION
Hi,

I have stumbled upon a bit obscure error message from the [ROS2 driver](https://github.com/bdaiinstitute/spot_ros2)  when attempting to send `sit` commands to the robot while it was also actively receiving velocity `movement` commands. This might also be related to:
* https://github.com/bdaiinstitute/spot_wrapper/issues/47
* https://github.com/bdaiinstitute/spot_ros2/issues/260

It makes sense that the `sit` commands will always be overridden by the `movement` commands and therefore the robot will refuse to sit down. However, the ROS2 driver responds to this by a outputting an error message, ex.: `[spot_ros2-5] [wrapper.py:236] Error when getting robot command feedback: bosdyn.api.RobotCommandFeedbackResponse (InternalServerError): Command not found, id: 62532`, which was quite confusing.

I have found the root cause of the error in this parsing logic: https://github.com/bdaiinstitute/spot_wrapper/blob/99ec4a61d9949e904e79474e0b832a072076d03e/spot_wrapper/wrapper.py#L223-L237
, specifically this status parsing:
https://github.com/bdaiinstitute/spot_wrapper/blob/99ec4a61d9949e904e79474e0b832a072076d03e/spot_wrapper/wrapper.py#L227-L230

The normal feedback response looks like this:
```
feedback {
  synchronized_feedback {
    mobility_command_feedback {
      sit_feedback {
        status: STATUS_IS_SITTING
      }
      status: STATUS_PROCESSING
    }
  }
}
```
However, when the command is overridden, the feedback response looks like this:
```
feedback {
  synchronized_feedback {
    mobility_command_feedback {
      status: STATUS_COMMAND_OVERRIDDEN
    }
  }
}
```
and this is where the the logic throws an exception because the `sit_feedback` section does not exist in the message at all. The same also applies to the `stand` command. I think the same might also apply to the `trajectory` command, but I have not tested that one.

I have added a top-level check for the value of `mobility_command_feedback.status` before any further parsing is performed. If this status is not currently `STATUS_PROCESSING` then the command is no longer valid and its `last_*_command` variable is reset together with a warning message.

This does not modify the actual robot behavior in any way, but avoids the obscure error message and instead handles the cases explicitly. I'm not sure if there are any larger refactors for the `AsyncIdle` class being currently in the works relating to https://github.com/bdaiinstitute/spot_wrapper/issues/47 and so if this small proposal has any value currently, but I am putting it out here.

I've also added a final check at the end, which might relate to the issue here https://github.com/bdaiinstitute/spot_ros2/issues/260. If the robot is in a `moving` state, the `sitting` and `standing` states will be set accordingly. This would make sense since the `movement` commands currently always force the robot to stand up a will override any `sit` and `stand` results. But, this may not be an optimal solution if the behavior changes in the future.