### PR TITLE
[SW-1245] Custom Gripper Calibration for Spot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest==7.3.1
 pytest-cov==4.1.0
 pytest-xdist==3.5.0
 setuptools==59.6.0
+open3d==0.18.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ bosdyn-mission==4.0.2
 grpcio==1.59.3
 image==1.5.33
 inflection==0.5.1
+open3d==0.18.0 
 protobuf==4.22.1
 pytest==7.3.1
 pytest-cov==4.1.0
 pytest-xdist==3.5.0
 setuptools==59.6.0
-open3d==0.18.0 

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -230,7 +230,7 @@ If you like the core tools of this utility, and you'd like a more portable versi
 use independent of Spot that doesn't depend on Spot Wrapper, you could recreate
 the CLI tool with no dependency on Spot Wrapper with the following command:
 ```
-cat calibration_util.py <(tail -n +5 automatic_camera_calibration_robot.py) <(tail -n +21 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
+cat calibration_util.py <(tail -n +3 automatic_camera_calibration_robot.py) <(tail -n +21 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
 ```
 The core capability above depends primarily on NumPy, OpenCV and standard Python libraries.
 

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -1,0 +1,242 @@
+# Automatic Robotic Stereo Camera Calibration Utility with Charuco Target (a.k.a Multi-Stereo Madness)
+TODO: placeholder for reference image not yet approved for release, hopefully added soon
+![spot eye in hand cal](spot_eye_in_hand_cal_thumbnail.jpg)
+
+# Table of Contents
+
+1. [***Overview***](#overview)
+2. [***Adapting Automatic Collection and Calibration to Your Scenario***](#adapting-automatic-collection-and-calibration-to-your-scenario)
+3. [***Calibrate Spot Manipulator Eye-In-Hand Cameras With the CLI Tool***](#calibrate-spot-manipulator-eye-in-hand-cameras-with-the-cli-tool)
+    - [Robot and Target Setup](#robot-and-target-setup)
+    - [Example Usage](#example-usage-aka-hand-specific-live-incantations)
+    - [Improving Calibration Quality](#improving-calibration-quality)
+    - [Using the Registered Information with Spot ROS 2](#using-the-registered-information-with-spot-ros-2)
+4. [***Using the CLI Tool To Calibrate On an Existing Dataset***](#using-the-cli-tool-to-calibrate-on-an-existing-dataset)
+5. [***Understanding the Output Calibration Config File from the CLI***](#understanding-the-output-calibration-config-file-from-the-cli)
+6. [Recreate the Core Calibration CLI Tool Without Depending On Spot Wrapper](#recreate-the-core-calibration-cli-tool-without-depending-on-spot-wrapper)
+
+# Overview
+This utility streamlines automatic
+camera calibration to **solve for the intrinsic and extrinsic parameters for two or more 
+cameras mounted in a fixed pose relative to each other on a robot**
+based off of moving the robot to view a Charuco target from different poses. If you already 
+have an existing dataset of synchronized stereo (or multi-stereo) photos of a Charuco target from different viewpoints, 
+you can use the CLI tool to compute the intrinsic/extrinsic parameters. Additionally,
+the CLI tool's saving capability allows to store multiple unique calibration runs in one configuration file
+with calibration metadata, to document related runs with different setups or parameters.
+
+This was developed to calibrate the two cameras at the 
+end of Spot's optional manipulator payload, while being **as general as possible 
+to be easily adapted to new robots and camera configurations. The core calibration utilities depend only on NumPy and OpenCV**
+
+This utility works by sampling viewpoints relative to the Charuco calibration board,
+visiting those viewpoints, and snapping photos with all cameras at each viewpoint. Then,
+these images are used to calibrate the desired cameras both individually and with respect to each
+other. This utility is particularly good at handling partial views of the board
+due to it's use of a charuco board. For more info, see ```calibration_util.py```, where the functions
+```get_multiple_perspective_camera_calibration_dataset``` and ```multistereo_calibration_charuco```
+do most of the heavy lifting.
+
+# Adapting Automatic Data Collection and Calibration to Your Scenario
+
+Assuming that you have a charuco board you'd like to automatically calibrate your cameras/robot with:
+
+**To calibrate a new robot with new cameras using the utility**, implement the abstract class ```AutomaticCameraCalibrationRobot``` from ```automatic_camera_calibration_robot.py``` 
+(Only five methods, that are likely analogous to what's needed for automatic calibration even if this utility isn't used.
+in Spot's case , excluding comments, it's under ~250 lines of code, see ```spot_in_hand_camera_calibration.py```),
+and pass the callable methods as arguments to ```get_multiple_perspective_camera_calibration_dataset``` from ```calibration_util.py``` (see ```calibrate_spot_hand_camera_cli.py``` for an example).
+
+**Adding a new camera to register with Spot's existing hand cameras** is as easy as adding a call to append
+the new camera image in ```SpotInHandCalibration.capture_images``` in ```spot_in_hand_camera_calibration.py``` to the existing
+list of images obtained with the default cameras (assuming that the new camera
+is fixed relative to the existing cameras.).
+
+
+# Calibrate Spot Manipulator Eye-In-Hand Cameras With the CLI tool
+
+There is an [existing method to calibrate the gripper cameras with the Spot Api](https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference#bosdyn-api-spot-GripperCameraCalibrationCommandRequest). However, you don't have 
+as much control and extensibility in the existing method as with this custom procedure.
+
+In Spot's hand, there is an RGB camera, as well as a ToF camera, which ```calibrate_spot_hand_camera_cli.py``` 
+automatically co-registers using the calibration utility via the default calibration board included
+with most Spots. You can also use a different board if you'd like, just set the right CLI parameters
+(see example usage below)
+
+## Robot and Target Setup
+Have Spot sit on the ground with the arm stowed such that nothing is within a meter of the robot.
+Spot should NOT be on it's charging dock.
+
+No program should have robot control authority. Make sure Spot is sitting 
+with the arm stowed before releasing robot authority.
+If you are using the ROS 2 Driver, disconnect from Spot. If you are using the tablet to control Spot, 
+select power icon (top) -> Advanced -> Release control.
+
+Place the Spot default calibration board on the ground leaning against something in front of Spot, so
+that the calibration board's pattern is facing Spot front (where the stowed arm points).
+The up arrow should point in the direction of the sky. The board should be tilted away from
+Spot at a 45 degree angle, so that the bottom of the board is closer Spot than the top of the board. The ground beneath
+the board should be at about a 45 degree angle from the board. The board's bottom should be about a meter away 
+from the front of Spot while sitting. Nothing should be within a meter of the robot.
+
+**See the reference image at the top of this README to see good board placement relative to Spot.**
+TODO: reference image not yet approved 
+
+When calibrating, Spot will stand up, ready its arm, lower its base slightly, and 
+lower its arm slightly. As soon as this happens, if Spot
+can see a Charuco board it will start to move the arm around for the calibration. 
+
+If the calibration board isn't placed at the right location, or there is more
+than one board visible to the robot, this may lead to potentially unsafe behavior, so be ready to
+E-Stop the robot at any moment. If the robot starts exhibiting unexpected behavior, stopping the program, 
+turning off the computer running the calibration, and hijacking control from the tablet can help stop robot movement.
+
+It is possible to calibrate at further distances 
+(see ```--dist_from_board_viewpoint_range``` arg), but the sampling of the viewpoint
+distance from the board must be feasible to reach with where the base of the 
+robot is started relative to the board. The previously recommended Spot and Target setup is what worked well 
+in testing for the default distance viewpoint range.
+
+After the calibration is finished, Spot stows it's arm and sits back down. At this point,
+it is safe to take control of Spot from the tablet or ROS 2 , even if the calibration script is still
+running. Just don't stop the script or it will stop calculating the parameters :) 
+
+## Example Usage (a.k.a Hand Specific Live Incantations)
+For all possible arguments to the Hand Specific CLI tool, run ```python3 calibrate_spot_hand_camera_cli.py -h```.
+Many parameters are customizable.
+
+If you'd like to calibrate depth to rgb, with rgb at default resolution, saving photos to ```~/my_collection/calibrated.yaml```, 
+here is an example CLI command template, under the default tag (recommended for first time)
+```
+python3 calibrate_spot_hand_camera_cli.py --ip 10.17.30.IP -u user -pw SECRET --data_path ~/my_collection/ \
+--save_data True --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0)]" \
+--spot_rgb_photo_width=640 --spot_rgb_photo_height=480 --tag default
+```
+If you'd like to load photos, and run the calibration with slightly different parameters, 
+while saving both the resuls and the parameters to same the config file as in the previous example.
+Here is an example CLI command template (from recorded images, no data collection)
+```
+python3 calibrate_spot_hand_camera_cli.py --data_path ~/my_collection/ --from_data \
+--result_path ~/my_collection/bottle_calibrated.yaml --photo_utilization_ratio 2 --stereo_pairs "[(1,0)]" \
+--spot_rgb_photo_width=640 --spot_rgb_photo_height=480 --tag less_photos_used_test_v1
+```
+If you'd like to calibrate depth to rgb, at a greater resolution, while sampling
+viewpoints at finer X-rotation steps relative to the board, and slightly further from the board
+with finer steps, here is an example CLI command template. Also,
+to demonstrate the stereo pairs argument, let's assume that you also want to find rgb to depth (redundant for 
+demonstration purposes), while writing to the same config files as above.
+```
+python3 calibrate_spot_hand_camera_cli.py --ip 10.17.30.IP -u user -pw SECRET --data_path ~/my_collection/ \
+--save_data True --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (0,1)]" \
+--spot_rgb_photo_width=1920 --spot_rgb_photo_height=1080 --x_axis_rot_viewpoint_range -10 10 1 \
+--dist_from_board_viewpoint_range .6 .9 .1
+```
+
+## Improving Calibration Quality
+If you find that the calibration quality isn't high enough, try a longer calibration
+with a wider variety of viewpoints (decrease the step size, increase the bounds). 
+The default calibration viewpoint parameters are meant to facilitate a quick  calibration
+even on more inexpensive hardware, and as such uses a minimal amount of viewpoints.
+
+## Using the Registered Information with Spot ROS 2
+
+First, collection a calibration with ```calibrate_spot_hand_camera_cli.py```.
+Make sure to use the default ```--stereo_pairs``` configuration, and the default tag configuration (```--tag default```).
+
+For the robot and target setup described, the default viewpoint ranges should suffice.
+
+```
+python3 calibrate_spot_hand_camera_cli.py --ip 10.17.30.IP -u user -pw SECRET --data_path ~/my_collection/ \
+--save_data True --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0)]" \
+--spot_rgb_photo_width=640 --spot_rgb_photo_height=480 --tag default
+```
+
+Then, if you have the [Spot ROS 2 Driver](https://github.com/bdaiinstitute/spot_ros2) installed,
+you can run a publisher to transform the depth image into the rgb images frame with the same image
+dimensions, so that finding the 3D location of a feature found in rgb can be as easy as passing
+the image feature pixel coordinates to the registered depth image, and extracting the 3D location.
+
+```
+ros2 run spot_ros2 calibrated_reregistered_hand_camera_depth_publisher.py --tag=default --calibration_path <SAVED_CAL> --robot_name <ROBOT_NAMESPACE> --topic_name /depth_registered/hand_custom_cal/image
+```
+
+You can treat the reregistered topic, (in the above example, ```<ROBOT_NAME>/depth_registered/hand_custom_cal/image```)
+as a drop in replacement by the registered image published by the default spot driver
+(```<ROBOT_NAME>/depth_registered/hand/image```). The registered depth can be easily used in tools 
+like downstream, like Open3d, (see [creating RGBD Images](https://www.open3d.org/docs/release/python_api/open3d.geometry.RGBDImage.html) and [creating color point clouds from RGBD Images](https://www.open3d.org/docs/release/python_api/open3d.geometry.PointCloud.html#open3d.geometry.PointCloud.create_from_rgbd_image)), due to matching image dimensions and registration
+to a shared frame.
+
+
+# Using the CLI Tool To Calibrate On an Existing Dataset
+To use the CLI Tool, please ensure that you have one parent folder, 
+where each camera has a folder under the parent (Numbered from 0 to N). Synchronized photos 
+for each camera should appear in their respective directories, where matching photos have ids, ascending
+upwards, starting from 0. The file structure should appear something like the following:
+```
+existing_dataset/
+├── 0/
+│   ├── 0.png # taken at viewpoint 0 
+│   ├── 1.png
+│   └── 2.png
+├── 1/
+│   ├── 0.png # taken at viewpoint 0
+│   ├── 1.png
+│   └── 2.png
+├── 2/
+│   ├── 0.png # taken at viewpoint 0
+│   ├── 1.png
+│   └── 2.png
+```
+
+To see all possible arguments for calibration, please run  ```python3 calibrate_multistereo_cameras_with_charuco_cli.py -h```.
+    Many parameters such as board proportions and Agmruco dictionary are customizable.
+
+If you'd like to register camera 1 to camera 0, and camera 2 to camera 0, you could do the following:
+```
+python3 calibrate_multistereo_cameras_with_charuco_cli.py --data_path ~/existing_dataset/ \
+--result_path ~/existing_dataset/eye_in_hand_calib.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (2, 0)]" \
+--tag default --unsafe_tag_save
+```
+
+# Understanding the Output Calibration Config File from the CLI
+A calibration produced with ```multistereo_calibration_charuco``` from ```calibration_util```
+can be saved as a ```.yaml```file with ```save_calibration_parameters``` from ```calibration_util```. Each calibration run
+that creates or modifies a config file is tagged with a unique name, to allow for tracking of several experiments, which is the main title.
+Under the main title, there are the fields relevant to the calibration
+Under ```intrinsic```, the intrinsic (camera matrix, distortion coefficents, and image height/width)
+for each camera are recorded as a flattened representation
+under the camera's index number as it appears in the list of images 
+returned by ```capture_images```. For example, if ```capture_images``` produces a list that is 
+```[image_by_primary_camera, image_by_reference_camera]```, then the intrinsic for the ```primary_camera```
+would be stored under ```0```, and the intrinsic for ```reference_camera``` would be stored under ```1```.
+
+Under ```extrinsic```, the first sublevel, again a camera index, corresponds to the camera index of which camera
+is the origin for the ```extrinsic``` transform between two cameras as the first
+field in a requested stereo pair. The second sublevel corresponds to the index of which camera
+the ```extrinsic``` maps to from the origin camera. Going with the example mentioned above, an extrinsic
+would be stored as 
+
+```
+extrinsic:
+    0: # primary camera index
+        1: # reference camera index
+            R: flattened_3x3_rotation_matrix_from_primary_to_reference_camera_now_9x1
+            T: 3x1_translation_matrix_from_primary_to_reference_camera
+```
+Additionally, arguments from an argparser can also be dumped into the yaml, which will be saved 
+under ```run_param```
+
+# Recreate the Core Calibration CLI Tool Without Depending On Spot Wrapper
+If you like the core tools of this utility, and you'd like a more portable version (```standalone_cli.py```) for 
+use independent of Spot that doesn't depend on Spot Wrapper, you could recreate
+the CLI tool with no dependency on Spot Wrapper with the following command:
+```
+cat calibration_util.py <(tail -n +5 automatic_camera_calibration_robot.py) <(tail -n +21 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
+```
+The core capability above depends primarily on NumPy, OpenCV and standard Python libraries.
+
+# Contributors
+Gary Lvov
+
+# Special Thanks To...
+Michael Pickett, Katie Hughes, Tiffany Cappellari, 
+Emmanuel Panov, Eric Rosen, Brian Okorn, Joseph St Germain and Ken Baker.

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -44,7 +44,7 @@ Assuming that you have a charuco board you'd like to automatically calibrate you
 **To calibrate a new robot with new cameras using the utility**, implement the abstract class ```AutomaticCameraCalibrationRobot``` from ```automatic_camera_calibration_robot.py``` 
 (Only five methods, that are likely analogous to what's needed for automatic calibration even if this utility isn't used.
 in Spot's case , excluding comments, it's under ~250 lines of code, see ```spot_in_hand_camera_calibration.py```),
-and pass the callable methods as arguments to ```get_multiple_perspective_camera_calibration_dataset``` from ```calibration_util.py``` (see ```calibrate_spot_hand_camera_cli.py``` for an example).
+and pass the implemented class as an argument to ```get_multiple_perspective_camera_calibration_dataset``` from ```calibration_util.py``` (see ```calibrate_spot_hand_camera_cli.py``` for an example).
 
 **Adding a new camera to register with Spot's existing hand cameras** is as easy as adding a call to append
 the new camera image in ```SpotInHandCalibration.capture_images``` in ```spot_in_hand_camera_calibration.py``` to the existing

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -27,7 +27,7 @@ with calibration metadata, to document related runs with different setups or par
 
 This was developed to calibrate the two cameras at the 
 end of Spot's optional manipulator payload, while being **as general as possible 
-to be easily adapted to new robots and camera configurations. The core calibration utilities depend only on NumPy and OpenCV**
+to be easily adapted to new robots and camera configurations. The core calibration utilities depend only on NumPy and OpenCV.**
 
 This utility works by sampling viewpoints relative to the Charuco calibration board,
 visiting those viewpoints, and snapping photos with all cameras at each viewpoint. Then,
@@ -64,7 +64,7 @@ with most Spots. You can also use a different board if you'd like, just set the 
 
 ## Robot and Target Setup
 Have Spot sit on the ground with the arm stowed such that nothing is within a meter of the robot.
-Spot should NOT be on it's charging dock.
+Spot should NOT be on its charging dock.
 
 No program should have robot control authority. Make sure Spot is sitting 
 with the arm stowed before releasing robot authority.
@@ -96,7 +96,7 @@ distance from the board must be feasible to reach with where the base of the
 robot is started relative to the board. The previously recommended Spot and Target setup is what worked well 
 in testing for the default distance viewpoint range.
 
-After the calibration is finished, Spot stows it's arm and sits back down. At this point,
+After the calibration is finished, Spot stows its arm and sits back down. At this point,
 it is safe to take control of Spot from the tablet or ROS 2 , even if the calibration script is still
 running. Just don't stop the script or it will stop calculating the parameters :) 
 
@@ -125,7 +125,7 @@ with finer steps, here is an example CLI command template. Also,
 to demonstrate the stereo pairs argument, let's assume that you also want to find rgb to depth (redundant for 
 demonstration purposes), while writing to the same config files as above.
 ```
-python3 calibrate_spot_hand_camera_cli.py --ip 10.17.30.IP -u user -pw SECRET --data_path ~/my_collection/ \
+python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_path ~/my_collection/ \
 --save_data True --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (0,1)]" \
 --spot_rgb_photo_width=1920 --spot_rgb_photo_height=1080 --x_axis_rot_viewpoint_range -10 10 1 \
 --dist_from_board_viewpoint_range .6 .9 .1
@@ -201,7 +201,7 @@ python3 calibrate_multistereo_cameras_with_charuco_cli.py --data_path ~/existing
 A calibration produced with ```multistereo_calibration_charuco``` from ```calibration_util```
 can be saved as a ```.yaml```file with ```save_calibration_parameters``` from ```calibration_util```. Each calibration run
 that creates or modifies a config file is tagged with a unique name, to allow for tracking of several experiments, which is the main title.
-Under the main title, there are the fields relevant to the calibration
+Under the main title, there are the fields relevant to the calibration.
 Under ```intrinsic```, the intrinsic (camera matrix, distortion coefficents, and image height/width)
 for each camera are recorded as a flattened representation
 under the camera's index number as it appears in the list of images 

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -140,7 +140,8 @@ even on more inexpensive hardware, and as such uses a minimal amount of viewpoin
 ## Using the Registered Information with Spot ROS 2
 If you have the [Spot ROS 2 Driver](https://github.com/bdaiinstitute/spot_ros2) installed,
 you can leverage the output of the automatic calibration to publish a depth image registered
-to the RGB image frame. For more info, see the [spot_ros2 main README](https://github.com/bdaiinstitute/spot_ros2/blob/main/README.md)
+to the RGB image frame. For more info, see the ```Optional Automatic Eye-in-Hand Stereo Calibration Routine for Manipulator (Arm) Payload```
+section in the [spot_ros2 main README](https://github.com/bdaiinstitute/spot_ros2/blob/main/README.md)
 
 # Using the CLI Tool To Calibrate On an Existing Dataset
 To use the CLI Tool, please ensure that you have one parent folder, 

--- a/spot_wrapper/calibration/automatic_camera_calibration_robot.py
+++ b/spot_wrapper/calibration/automatic_camera_calibration_robot.py
@@ -1,0 +1,132 @@
+# Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
+
+# What's below can be used in standalone tool
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+
+
+class AutomaticCameraCalibrationRobot(ABC):
+    @abstractmethod
+    def capture_images(self) -> Union[List, np.ndarray]:
+        """
+        Capture images from the cameras you wish to calibrate at the same moment in time
+        (time-synchronized). Then, construct either a list or a NumPy array
+        of these images. This will be called every time that your robot reaches a new
+        calibration viewpoint, so ensure that image order to camera correlation is consistent
+        across all calls. Also, it is important to ensure that the photos are as time-synchronized
+        as possible, with as little motion blur as possible.
+
+        Returns:
+            Union[List, np.ndarray]: The time-synchronized images from all relevant cameras.
+        """
+        pass
+
+    @abstractmethod
+    def localize_target_to_principal_camera(self, images: Union[List, np.ndarray]) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Localize the charuco board relative to what is considered
+        the principal camera for the calibration. This could be done
+        either visually, or via kinematics and fixing the board relative
+        to the robot. Visually is more flexible, although this
+        implies some knowledge of the principal cameras intrinsics.
+
+        In this case, principal camera could be an actual camera, or could also be a "virtual"
+        camera. The principal camera's frame is just what frame is used to sample viewpoints in.
+
+        The board pose's translation should be at the center of the board, with the orientation
+        in OpenCV format, where the +Z points out of the board with
+        the other axis being parallel to the sides of the board.
+
+        Your camera pose should be in OpenCV/ROS convention, where
+        # +x should point to the right in the image
+        # +y should point down in the image
+        # +z should point into to plane of the image
+
+        If you'd like to do this through visual localization, you can use
+
+        def est_camera_t_charuco_board_center(
+                img: np.ndarray,
+                charuco_board: cv2.aruco_CharucoBoard,
+                aruco_dict: cv2.aruco_Dictionary,
+                camera_matrix: np.ndarray,
+                dist_coeffs: np.ndarray,
+            )
+        from calibration_util.py
+
+        Args:
+            images (Union[List, np.ndarray]): the images that could be used to determine
+                how far the target is from the "principal" camera
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: _description_
+        """
+        pass
+
+    @abstractmethod
+    def move_cameras_to_see_calibration_target(self) -> np.ndarray:
+        """
+        This is a robot specific sequence to start the calibration. This
+        could be as simple as a heuristic to move the robot to a known pose where
+        it is generally looking at the checkerboard, or this could be a more sophisticated
+        sequence to look around in the scene until a board is found
+        (for example, grabbing images with self.capture_images(),
+        and checking if a board is found with detect_charuco_corners from calibration_util.py)
+
+        Returns:
+            np.ndarray: the 4x4 homogenous transform of the starting pose where the calibration
+                board is visible.
+        """
+        pass
+
+    @abstractmethod
+    def offset_cameras_from_current_view(
+        self,
+        transform_offset: np.ndarray,
+        origin_t_planning_frame: Optional[np.ndarray] = None,
+        duration_sec: float = 1.0,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Move the robot to a desired position, such that the cameras move by transform_offset.
+        This is how the robot visits desired viewpoints.
+
+        IMPORTANT: You likely have to convert transform_offset from the "principal"
+        camera frame into the planning frame (if the camera frame isn't the planning frame).
+        This can be done by calling
+
+        convert_camera_t_viewpoint_to_origin_t_planning_frame(
+            origin_t_planning_frame=origin_t_planning_frame,
+            planning_frame_t_opencv_camera=HOMOGENOUS_TRANSFORM_FROM_PLANNING_FRAME_TO_OPENCV_CAM,
+            opencv_camera_t_viewpoint=transform_offset,
+        )
+        from calibration_util.py
+
+        Your camera pose should be in OpenCV/ROS convention, where
+        +x should point to the right in the image
+        +y should point down in the image
+        +z should point into to plane of the image
+
+        Args:
+            transform_offset (np.ndarray): the 4x4 homogenous transform of
+                how far you'd like to shift your cameras
+            origin_t_planning_frame (Optional[np.ndarray], optional): the 4x4 homogenous
+                transform of your robot origin to planning frame. Could be hard-coded
+                or read off of the robot. Defaults to None.
+            duration_sec (float, optional): How many seconds provided to execute
+                the move. Defaults to 1.0.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: the 4x4 homogenous transform of origin_t_planning_frame
+                before the move, and the 4x4 homogenous transform of origin_t_planning_frame
+                after the move.
+        """
+        pass
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """
+        Cleanup the robot connection, and disconnect so that other programs can resume
+        control of the robot while this program continues to solve the calibration parameters.
+        """
+        pass

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -81,7 +81,8 @@ def calibrator_cli() -> argparse.ArgumentParser:
             "what index in the list of images' corresponding camera"
             "to calibrate to what camera. Say capture_images returns [rgb_img, depth_img]"
             "and you want to register depth to rgb, then the desired stereo pair"
-            "is [(1,0)]. If you want to register more than one pair, you can do it like [(1, 0), (2,0)]."
+            'is "[(1,0)]". If you want to register more than one pair, you can do it like "[(1, 0), (2,0)]."'
+            "Make sure to put the stereo pairs in quotes so bash doesn't complain"
         ),
     )
 

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -1,0 +1,223 @@
+# Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
+
+import argparse
+import ast
+import logging
+from typing import List, Tuple, Union
+
+import cv2
+import numpy as np
+
+from spot_wrapper.calibration.calibration_util import (
+    load_images_from_path,
+    multistereo_calibration_charuco,
+    save_calibration_parameters,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+
+def calibration_helper(
+    images: Union[List[np.ndarray], np.ndarray],
+    args: argparse.Namespace,
+    charuco: cv2.aruco_CharucoBoard,
+    aruco_dict: cv2.aruco_Dictionary,
+):
+    logger.warning(
+        f"Calibrating from {len(images)} images.. for every "
+        f"{args.photo_utilization_ratio} recorded photos 1 is used to calibrate"
+    )
+    calibration = multistereo_calibration_charuco(
+        images[:: args.photo_utilization_ratio],
+        desired_stereo_pairs=args.stereo_pairs,
+        charuco_board=charuco,
+        aruco_dict=aruco_dict,
+    )
+    logger.info(f"Finished script, obtained {calibration}")
+    logger.info("Saving calibration param")
+    save_calibration_parameters(
+        data=calibration,
+        output_path=args.result_path,
+        num_images=len(images[:: args.photo_utilization_ratio]),
+        tag=args.tag,
+        parser_args=args,
+        unsafe=args.unsafe_tag_save,
+    )
+
+
+def main():
+    parser = calibrator_cli()
+    args = parser.parse_args()
+    if hasattr(cv2.aruco, args.dict_size):
+        aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
+    else:
+        raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
+    charuco = cv2.aruco.CharucoBoard_create(
+        args.num_checkers_width,
+        args.num_checkers_height,
+        args.checker_dim,
+        args.marker_dim,
+        aruco_dict,
+    )
+    logger.info(f"Loading images from {args.data_path}")
+    images = load_images_from_path(args.data_path)
+    calibration_helper(images=images, args=args, charuco=charuco, aruco_dict=aruco_dict)
+
+
+def calibrator_cli() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser("Calibrate Eye-In Hand Camera System :)")
+    # Calculations
+    parser.add_argument(
+        "--stereo_pairs",
+        "-sp",
+        type=parse_tuple_list,
+        required=True,
+        default=[(1, 0)],
+        help=(
+            "Capture images returns a list of images. Stereo pairs correspond to"
+            "what index in the list of images' corresponding camera"
+            "to calibrate to what camera. Say capture_images returns [rgb_img, depth_img]"
+            "and you want to register depth to rgb, then the desired stereo pair"
+            "is [(1,0)]. If you want to register more than one pair, you can do it like [(1, 0), (2,0)]."
+        ),
+    )
+
+    parser.add_argument(
+        "--photo_utilization_ratio",
+        "-pur",
+        dest="photo_utilization_ratio",
+        type=int,
+        default=1,
+        help=(
+            "Photos that are collected/loaded vs. used for calibration are in a 1 to"
+            "photo utilization ratio. For getting a rough guess on cheaper hardware"
+            "without losing collection fidelity. For example, set to 2 to only use half the photos."
+        ),
+    )
+
+    # calibration param
+    parser.add_argument(
+        "--num_checkers_width",
+        "-ncw",
+        dest="num_checkers_width",
+        type=int,
+        help="How many checkers wide is your board",
+        default=9,
+    )
+
+    parser.add_argument(
+        "--num_checkers_height",
+        "-nch",
+        dest="num_checkers_height",
+        type=int,
+        help="How many checkers tall is your board",
+        default=4,
+    )
+
+    parser.add_argument(
+        "--dict_size",
+        type=str,
+        choices=[
+            "DICT_4X4_50",
+            "DICT_4X4_100",
+            "DICT_4X4_250",
+            "DICT_4X4_1000",
+            "DICT_5X5_50",
+            "DICT_5X5_100",
+            "DICT_5X5_250",
+            "DICT_5X5_1000",
+            "DICT_6X6_50",
+            "DICT_6X6_100",
+            "DICT_6X6_250",
+            "DICT_6X6_1000",
+            "DICT_7X7_50",
+            "DICT_7X7_100",
+            "DICT_7X7_250",
+            "DICT_7X7_1000",
+            "DICT_ARUCO_ORIGINAL",
+        ],
+        default="DICT_4X4_50",
+        help="Choose the ArUco dictionary size.",
+    )
+
+    parser.add_argument(
+        "--checker_dim",
+        "-cd",
+        dest="checker_dim",
+        type=float,
+        default=0.115,
+        help="Checker size in meters",
+    )
+
+    parser.add_argument(
+        "--marker_dim",
+        "-md",
+        dest="marker_dim",
+        type=float,
+        default=0.09,
+        help="Aruco Marker size in meters",
+    )
+
+    # path and saving
+    parser.add_argument(
+        "--data_path",
+        "-dp",
+        dest="data_path",
+        type=str,
+        help="The path in which to save images",
+        default=None,
+    )
+
+    parser.add_argument(
+        "--result_path",
+        "-rp",
+        dest="result_path",
+        type=str,
+        required=True,
+        help="Where to store calibration result as file",
+    )
+
+    parser.add_argument(
+        "--tag",
+        "-t",
+        dest="tag",
+        type=str,
+        required=False,
+        default="default",
+        help=(
+            "What heading to put for the calibration in the config file."
+            "If this is your first time running, the tag should be set to default "
+            "for the sake of interoperability with other functionality."
+            "If this is a shared config file with other people, perhaps put"
+            "a unique identifier, or default, if you'd like to override"
+            "for everyone."
+        ),
+    )
+
+    parser.add_argument(
+        "--unsafe_tag_save",
+        action="store_true",
+        help="If set, skips safety checks for tagging calibration.",
+    )
+
+    return parser
+
+
+# collection
+def parse_tuple_list(string: str) -> List[Tuple[int, int]]:
+    try:
+        # Use ast.literal_eval to safely evaluate the string as a Python expression
+        value = ast.literal_eval(string)
+        if isinstance(value, list) and all(isinstance(t, tuple) and len(t) == 2 for t in value):
+            return value
+        else:
+            raise argparse.ArgumentTypeError(f"Expected a list of tuples, but got: {string}")
+    except (ValueError, SyntaxError):
+        raise argparse.ArgumentTypeError(f"Invalid tuple list format: {string}")
+
+
+if __name__ == "__main__":
+    main()

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -58,6 +58,12 @@ def spot_main() -> None:
             ),
         )
 
+        try:
+            args.robot_name = in_hand_bot.robot.get_cached_robot_id().nickname
+        except Exception:
+            logger.warning("Could not determine cached robot nickname, saving name as unknown")
+            args.robot_name = "unknown"
+
         images = get_multiple_perspective_camera_calibration_dataset(
             auto_cam_cal_robot=in_hand_bot,
             max_num_images=args.max_num_images,
@@ -73,6 +79,7 @@ def spot_main() -> None:
     else:
         logger.info(f"Loading images from {args.data_path}")
         images = load_images_from_path(args.data_path)
+
     calibration_helper(images=images, args=args, charuco=charuco, aruco_dict=aruco_dict)
 
 

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -113,7 +113,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         nargs="+",
         type=float,
         dest="dist_from_board_viewpoint_range",
-        default=[0.6, 0.9, 0.2],
+        default=[0.6, 0.7, 0.2],
         help=(
             "What distances to conduct calibrations at relative to the board. (along the normal vector) "
             "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -1,0 +1,201 @@
+# Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
+
+import argparse
+import logging
+from time import sleep
+
+import cv2
+import numpy as np
+
+from spot_wrapper.calibration.calibrate_multistereo_cameras_with_charuco_cli import (
+    calibration_helper,
+    calibrator_cli,
+)
+from spot_wrapper.calibration.calibration_util import (
+    get_multiple_perspective_camera_calibration_dataset,
+    load_images_from_path,
+)
+from spot_wrapper.calibration.spot_in_hand_camera_calibration import (
+    SpotInHandCalibration,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def spot_main() -> None:
+    parser = spot_cli(calibrator_cli())
+    args = parser.parse_args()
+    if hasattr(cv2.aruco, args.dict_size):
+        aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
+    else:
+        raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
+    charuco = cv2.aruco.CharucoBoard_create(
+        args.num_checkers_width,
+        args.num_checkers_height,
+        args.checker_dim,
+        args.marker_dim,
+        aruco_dict,
+    )
+
+    if not args.from_data:
+        logger.warning("This script moves the robot around. !!! USE AT YOUR OWN RISK !!!")
+        logger.warning("HOLD Ctrl + C NOW TO CANCEL")
+        logger.warning("The calibration board should be about a meter away with nothing within a meter of the robot.")
+        logger.warning("The robot should NOT be docked, and nobody should have robot control")
+        sleep(5)
+
+        in_hand_bot = SpotInHandCalibration(args.ip, args.username, args.password)
+        in_hand_bot._set_localization_param(
+            charuco_board=charuco,
+            aruco_dict=aruco_dict,
+            resolution=(
+                args.spot_rgb_photo_width,
+                args.spot_rgb_photo_height,
+            ),
+        )
+
+        images = get_multiple_perspective_camera_calibration_dataset(
+            auto_cam_cal_robot=in_hand_bot,
+            max_num_images=args.max_num_images,
+            distances=np.arange(*args.dist_from_board_viewpoint_range),
+            x_axis_rots=np.arange(*args.x_axis_rot_viewpoint_range),
+            y_axis_rots=np.arange(*args.y_axis_rot_viewpoint_range),
+            z_axis_rots=np.arange(*args.z_axis_rot_viewpoint_range),
+            use_degrees=args.degrees,
+            settle_time=args.settle_time,
+            data_path=args.data_path,
+            save_data=args.save_data,
+        )
+    else:
+        logger.info(f"Loading images from {args.data_path}")
+        images = load_images_from_path(args.data_path)
+    calibration_helper(images=images, args=args, charuco=charuco, aruco_dict=aruco_dict)
+
+
+def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
+    if parser is None:
+        parser = calibrator_cli()
+    parser.add_argument(
+        "--ip",
+        "-i",
+        dest="ip",
+        type=str,
+        help="The IP address of the Robot to calibrate",
+        required=False,
+    )
+    parser.add_argument(
+        "--user",
+        "-u",
+        "--username",
+        dest="username",
+        type=str,
+        help="Robot Username",
+        required=False,
+    )
+    parser.add_argument(
+        "--pass",
+        "-pw",
+        "--password",
+        dest="password",
+        type=str,
+        help="Robot Password",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--dist_from_board_viewpoint_range",
+        "-dfbvr",
+        nargs="+",
+        type=float,
+        dest="dist_from_board_viewpoint_range",
+        default=[0.6, 0.9, 0.1],
+        help=(
+            "What distances to conduct calibrations at relative to the board. (along the normal vector) "
+            "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "
+            "These are used to sample viewpoints for automatic collection. "
+        ),
+    )
+    parser.add_argument(
+        "--degrees",
+        "-d",
+        default=True,
+        type=bool,
+        help="Whether to use degrees for rot ranges",
+    )
+    for axis in ["x", "y", "z"]:
+        parser.add_argument(
+            f"--{axis}_axis_rot_viewpoint_range",
+            f"-{axis}arvr",
+            nargs="+",
+            type=float,
+            default=[-10, 11, 5],
+            dest=f"{axis}_axis_rot_viewpoint_range",
+            help=(
+                f"What range of viewpoints around {axis}-axis to sample relative to boards normal vector. "
+                "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep "
+                "These are used to sample viewpoints for automatic collection. "
+                "Assuming that the camera pose is in opencv/ROS format. "
+            ),
+        )
+
+    parser.add_argument(
+        "--max_num_images",
+        dest="max_num_images",
+        type=int,
+        default=10000,
+        help="The maximum number of images",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--settle_time",
+        "-st",
+        dest="settle_time",
+        type=float,
+        default=0.25,
+        help="How long to wait after movement to take a picture; don't want motion blur",
+    )
+
+    parser.add_argument(
+        "--spot_rgb_photo_width",
+        "-dpw",
+        type=int,
+        default=640,
+        dest="spot_rgb_photo_width",
+        help="What resolution use for Spot's RGB Hand Camera (width). Currently, only 640 and 1920 are supported",
+    )
+
+    parser.add_argument(
+        "--spot_rgb_photo_height",
+        "-dph",
+        type=int,
+        default=480,
+        help="What resolution use for Spot's RGB Hand Camera (width). Currently, only 480 and 1080 are supported",
+    )
+    # path things
+    parser.add_argument(
+        "--save_data",
+        "-sd",
+        dest="save_data",
+        type=bool,
+        default=True,
+        help="whether to save the images to file",
+    )
+
+    parser.add_argument(
+        "--from_data",
+        "-fd",
+        dest="from_data",
+        action="store_true",
+        help="Whether to only calibrate from recorded dataset on file.",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    spot_main()

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -82,6 +82,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument(
         "--ip",
         "-i",
+        "-ip",
         dest="ip",
         type=str,
         help="The IP address of the Robot to calibrate",
@@ -112,7 +113,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         nargs="+",
         type=float,
         dest="dist_from_board_viewpoint_range",
-        default=[0.6, 0.9, 0.1],
+        default=[0.6, 0.9, 0.2],
         help=(
             "What distances to conduct calibrations at relative to the board. (along the normal vector) "
             "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "
@@ -132,7 +133,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
             f"-{axis}arvr",
             nargs="+",
             type=float,
-            default=[-10, 11, 5],
+            default=[-30, 31, 10],
             dest=f"{axis}_axis_rot_viewpoint_range",
             help=(
                 f"What range of viewpoints around {axis}-axis to sample relative to boards normal vector. "
@@ -156,7 +157,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         "-st",
         dest="settle_time",
         type=float,
-        default=0.25,
+        default=0.5,
         help="How long to wait after movement to take a picture; don't want motion blur",
     )
 

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -737,6 +737,9 @@ def load_images_from_path(path: str) -> np.ndarray:
     """
     Load image dataset from path in a way that's compatible with multistereo_calibration_charuco.
 
+    See Using the CLI Tool To Calibrate On an Existing Dataset section in the README
+    to see the expected folder/data structure for this method to work
+
     Args:
         path (str): The parent path
 

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -198,19 +198,24 @@ def multistereo_calibration_charuco(
         raise ValueError("Stereo Madness requires more than one camera. Use the monocular method instead.")
     else:  # More than one camera - Multi-Stereo Madness ;p
         for idx in range(num_cams):
-            try:
-                _ = camera_matrices[idx]
-            except KeyError:
+            if idx not in camera_matrices:
                 camera_matrices[idx] = None
-            try:
-                _ = dist_coeffs[idx]
-            except KeyError:
+            if idx not in dist_coeffs:
                 dist_coeffs[idx] = None
 
         if desired_stereo_pairs is None:
             desired_stereo_pairs = []
             for idx in range(1, num_cams):
-                desired_stereo_pairs.append((0, idx))  # just register all to 0th cam
+                """
+                Desired stereo pairs is a mapping, where the 0th index is the origin (base)
+                frame, where the reference frame is defined within the origin (base) frame's
+                coordinate system. The reference frame is the 1st index.
+
+                By Default, if desired_stereo_pairs is None,
+                then each camera's intrinsic is defined in the 0th camera's frame,
+                so this is set as the origin for all stereo calibrations
+                """
+                desired_stereo_pairs.append((0, idx))  # just register all in 0th cam frame
 
         for idx, pair in enumerate(desired_stereo_pairs):
             for index in pair:

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -489,7 +489,7 @@ def stereo_calibration_charuco(
 
         if len(obj_points_all) > 0:
             logger.info(f"Collected {len(obj_points_all)} shared point sets for stereo calibration.")
-            _, _, _, _, _, R, T, E, F = cv2.stereoCalibrate(
+            _, _, _, _, _, R, T, _, _ = cv2.stereoCalibrate(
                 obj_points_all,
                 img_points_origin,
                 img_points_reference,
@@ -621,11 +621,11 @@ def convert_camera_t_viewpoint_to_origin_t_planning_frame(
 def get_relative_viewpoints_from_board_pose_and_param(
     R_board: np.ndarray,
     tvec: np.ndarray,
-    distances: np.ndarray = np.arange(0.5, 0.7, 0.1),
-    x_axis_rots: np.ndarray = np.arange(-20, 21, 5),
-    y_axis_rots: np.ndarray = np.arange(-20, 21, 5),
-    z_axis_rots: np.ndarray = np.array([-20, 21, 5]),
-    R_align_board_frame_with_camera: np.ndarray = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]]),
+    distances: Optional[np.ndarray] = None,
+    x_axis_rots: Optional[np.ndarray] = None,
+    y_axis_rots: Optional[np.ndarray] = None,
+    z_axis_rots: Optional[np.ndarray] = None,
+    R_align_board_frame_with_camera: Optional[np.ndarray] = None,
     degree_offset_rotations: bool = True,
 ) -> List[np.ndarray]:
     """
@@ -674,6 +674,17 @@ def get_relative_viewpoints_from_board_pose_and_param(
         List[np.ndarray]: a list of 4x4 homogenous transforms to visit in the "principal" cameras
             frame
     """
+    if distances is None:
+        distances = np.arange(0.5, 0.7, 0.1)
+    if x_axis_rots is None:
+        x_axis_rots = np.arange(-20, 21, 5)
+    if y_axis_rots is None:
+        y_axis_rots = np.arange(-20, 21, 5)
+    if z_axis_rots is None:
+        z_axis_rots = np.arange(-20, 21, 5)
+    if R_align_board_frame_with_camera is None:
+        R_align_board_frame_with_camera = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]])
+
     if degree_offset_rotations:
         x_axis_rots = [radians(deg) for deg in x_axis_rots]
         y_axis_rots = [radians(deg) for deg in y_axis_rots]

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -1,0 +1,916 @@
+# Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
+
+import argparse
+import logging
+import os
+import re
+from datetime import datetime
+from glob import glob
+from math import radians
+from time import sleep
+from typing import Dict, List, Optional, Tuple, Union
+
+import cv2
+import numpy as np
+import yaml
+
+from spot_wrapper.calibration.automatic_camera_calibration_robot import (
+    AutomaticCameraCalibrationRobot,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+)
+
+logger = logging.getLogger(__name__)
+
+SPOT_DEFAULT_ARUCO_DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
+SPOT_DEFAULT_CHARUCO = cv2.aruco.CharucoBoard_create(9, 4, 0.115, 0.09, SPOT_DEFAULT_ARUCO_DICT)
+
+
+def get_multiple_perspective_camera_calibration_dataset(
+    auto_cam_cal_robot: AutomaticCameraCalibrationRobot,
+    max_num_images: int = 10000,
+    distances: np.ndarray = np.arange(0.5, 0.8, 0.1),
+    x_axis_rots: np.ndarray = np.arange(-21, 21, 5),
+    y_axis_rots: np.ndarray = np.arange(-21, 21, 5),
+    z_axis_rots: np.ndarray = np.array([-21, 21, 5]),
+    use_degrees: bool = True,
+    settle_time: float = 0.1,
+    data_path: str = os.path.expanduser("~"),
+    save_data: Optional[bool] = True,
+) -> np.ndarray:
+    """
+    Move the robot around to look at the calibration target from different viewpoints,
+    capturing time-synchronized
+    consistent-ordering images from every camera at each viewpoint.
+
+    Args:
+        auto_cam_cal_robot (AutomaticCameraCalibrationRobot): The robot to automatically
+            calibrate.
+        max_num_images (int, optional): The maximum amount of images to take with EACH camera,
+            (so max total number of captures) cuts out the calibration early if this number is
+             reached prior to all viewpoints being reached . Defaults to 100.
+        distances (np.ndarray, optional): What distances
+            away from the calibration board's pose (along the Z axis)
+            to sample calibration viewpoints from. Defaults to np.arange(0.5, 0.8, 0.1).
+        x_axis_rots (np.ndarray, optional): What
+            x-axis rotations relative to the camera viewing the board orthogonally
+            to apply to sample viewpoints. Defaults to np.arange(-21, 21, 5).
+        y_axis_rots (np.ndarray, optional): What
+            y-axis rotations relative to the camera viewing the board orthogonally
+            to apply to sample viewpoints. Defaults to np.arange(-21, 21, 5).
+        z_axis_rots (np.ndarray, optional): What
+            z-axis rotations relative to the camera viewing the board orthogonally
+            to aply to sample viewpoints. Defaults to np.array([-21, 21, 5]).
+        use_degrees (bool, optional): Whether to use degrees for the rotations
+            about the axis to sample viewpoints from. Defaults to True.
+        settle_time (float, optional): How long to wait in seconds after moving the robot
+            to a new viewpoint prior to taking a picture. Defaults to 0.1.
+        data_path (str, optional): where to save
+            the calibration dataset, if it's being saved. Defaults to os.path.expanduser("~").
+        save_data (Optional[bool], optional): whether to save the calibration
+            dataset. Defaults to True.
+
+    Returns:
+        np.ndarray: A list of lists, where the internal list is a time-synchronized
+            camera-ordering-consistent list of images of the calibration target.
+    """
+    primed_pose = auto_cam_cal_robot.move_cameras_to_see_calibration_target()
+    logger.info("Primed arm...")
+    sleep(settle_time)
+    images = auto_cam_cal_robot.capture_images()
+    capture_data = {}
+    capture_data["primed_images"] = images
+    capture_data["primed_pose"] = primed_pose
+
+    R_vision_to_target, tvec_vision_to_target = auto_cam_cal_robot.localize_target_to_principal_camera(images)
+    viewpoints = get_relative_viewpoints_from_board_pose_and_param(
+        R_vision_to_target,
+        tvec_vision_to_target,
+        distances=distances,
+        x_axis_rots=x_axis_rots,
+        y_axis_rots=y_axis_rots,
+        z_axis_rots=z_axis_rots,
+        degree_offset_rotations=use_degrees,
+    )
+    calibration_images = []
+    logger.info("Beginning Calibration")
+    idx = 0
+    while idx < max_num_images and idx < len(viewpoints):
+        logger.info(f"Visiting viewpoint {idx} of {min(len(viewpoints), max_num_images)}")
+        viewpoint = viewpoints[idx]
+        initial_pose, new_pose = auto_cam_cal_robot.offset_cameras_from_current_view(
+            transform_offset=viewpoint,
+            origin_t_planning_frame=primed_pose,
+            duration_sec=0.1,
+        )
+        logger.info("At viewpoint, waiting to settle")
+        sleep(settle_time)
+        images = auto_cam_cal_robot.capture_images()
+        logger.info("Snapped pics ;)")
+        calibration_images.append(images)
+        idx = len(calibration_images)
+        if save_data:
+            if idx == 1:
+                create_calibration_save_folders(data_path, len(images))
+            logger.info(f"Saving image batch {idx}")
+            for jdx, image in enumerate(images):
+                cv2.imwrite(
+                    os.path.join(data_path, str(jdx), f"{idx}.png"),
+                    image,
+                )
+    calibration_images = np.array(calibration_images, dtype=object)
+    auto_cam_cal_robot.shutdown()
+    return np.array(calibration_images, dtype=object)
+
+
+def multistereo_calibration_charuco(
+    images: np.ndarray,
+    desired_stereo_pairs: Optional[List[Tuple[int, int]]] = None,
+    charuco_board: cv2.aruco_CharucoBoard = SPOT_DEFAULT_CHARUCO,
+    aruco_dict: cv2.aruco_Dictionary = SPOT_DEFAULT_ARUCO_DICT,
+    camera_matrices: Optional[Dict] = {},
+    dist_coeffs: Optional[Dict] = {},
+) -> Dict:
+    """
+    Calibrates the intrinsic and extrinsic parameters for multiple stereo camera pairs
+    using Charuco board markers. This function performs stereo calibration on a series of
+    time-synchronized images
+    captured by multiple cameras. It uses a Charuco board for calibration and returns
+    the calibrated intrinsic and extrinsic parameters for the specified stereo camera pairs.
+
+    Args:
+        images (np.ndarray): A 2D array of time-synchronized camera captures. The array should
+            be of shape (n, m), where 'n' represents the number of time-synchronized captures
+            and 'm' represents the number of cameras. Each internal list corresponds to a set
+            of images captured at the same time across multiple cameras.
+
+        desired_stereo_pairs (Optional[List[Tuple[int, int]]], optional): A list of tuples
+            specifying the pairs of camera indices to be calibrated. The indices refer to the
+            cameras based on their positions in the `images` array. For example, index `0`
+            corresponds to the first camera, index `1` to the second camera, and so forth,
+            up to `n-1` (where `n` is the number of cameras).
+            If None, all cameras are registered to the first camera (index `0`). Defaults to None.
+
+            The relationship between `desired_stereo_pairs` and `images` is crucial. Each tuple in
+            `desired_stereo_pairs` should be in the form
+            `(origin_camera_idx, reference_camera_idx)`,
+            where `origin_camera_idx` and `reference_camera_idx` correspond to the
+            indices of the cameras in the `images` array. For each stereo pair,
+            the function attempts to calibrate the `origin_camera_idx`
+            relative to the `reference_camera_idx`. If no pairs are provided,
+            the function defaults to registering
+            all cameras to the first camera (index `0`).
+
+        charuco_board (cv2.aruco_CharucoBoard, optional): The Charuco board configuration used
+            for calibration. Defaults to SPOT_DEFAULT_CHARUCO.
+
+        aruco_dict (cv2.aruco_Dictionary, optional): The Aruco dictionary used
+            to detect the markers. Defaults to SPOT_DEFAULT_ARUCO_DICT.
+
+        camera_matrices (Optional[Dict], optional): A dictionary mapping camera indices
+            to their existing camera matrices. If a matrix is not provided for a camera,
+            it will be computed during calibration
+            if that camera is part of a stereo pair. Defaults to an empty dictionary.
+
+        dist_coeffs (Optional[Dict], optional): A dictionary mapping camera indices
+            to their distortion coefficients.
+            If coefficients are not provided for a camera, they will be computed during calibration.
+            Defaults to an empty dictionary.
+
+    Raises:
+        ValueError: Raised if fewer than two cameras are provided, as stereo calibration
+            requires at least two cameras.
+        ValueError: Raised if a stereo pair includes the same camera twice.
+        ValueError: Raised if a camera in a stereo pair cannot be calibrated.
+
+    Returns:
+        Dict: A dictionary containing the calibrated intrinsic and extrinsic parameters
+            for the specified stereo pairs.
+        The keys are formatted as "origin_camera_idx_reference_camera_idx",
+            and the values contain the calibration data.
+
+    """
+    calibration = {}
+    num_cams = images.shape[1]
+    if num_cams == 0 or num_cams == 1:
+        raise ValueError("Stereo Madness requires more than one camera. Use the monocular method instead.")
+    else:  # More than one camera - Multi-Stereo Madness ;p
+        for idx in range(num_cams):
+            try:
+                _ = camera_matrices[idx]
+            except KeyError:
+                camera_matrices[idx] = None
+            try:
+                _ = dist_coeffs[idx]
+            except KeyError:
+                dist_coeffs[idx] = None
+
+        if desired_stereo_pairs is None:
+            desired_stereo_pairs = []
+            for idx in range(1, num_cams):
+                desired_stereo_pairs.append((0, idx))  # just register all to 0th cam
+
+        for idx, pair in enumerate(desired_stereo_pairs):
+            for index in pair:
+                if index < 0 or index > num_cams:
+                    raise ValueError(
+                        f"Requested to stereo register non-existent camera index {index} out of {num_cams}"
+                    )
+            origin_camera_idx = pair[0]
+            reference_camera_idx = pair[1]
+
+            if pair[0] == pair[1]:
+                logging.warning(
+                    "You requested to register a camera to itself. Ignoring,and continuing to the next stereo pair."
+                )
+                continue
+            logging.info(
+                f"Attempting to register {origin_camera_idx}"
+                f"to {reference_camera_idx}, pair {idx} of"
+                f" {len(desired_stereo_pairs)}"
+            )
+            try:
+                key = str(origin_camera_idx) + "_" + str(reference_camera_idx)
+                stereo_dict = stereo_calibration_charuco(
+                    origin_images=images[:, origin_camera_idx],
+                    reference_images=images[:, reference_camera_idx],
+                    charuco_board=charuco_board,
+                    aruco_dict=aruco_dict,
+                    camera_matrix_origin=camera_matrices[origin_camera_idx],
+                    dist_coeffs_origin=dist_coeffs[origin_camera_idx],
+                    camera_matrix_reference=camera_matrices[reference_camera_idx],
+                    dist_coeffs_reference=dist_coeffs[reference_camera_idx],
+                )
+                camera_matrices[origin_camera_idx] = stereo_dict["camera_matrix_origin"]
+                dist_coeffs[origin_camera_idx] = stereo_dict["dist_coeffs_origin"]
+                camera_matrices[reference_camera_idx] = stereo_dict["camera_matrix_reference"]
+                dist_coeffs[reference_camera_idx] = stereo_dict["dist_coeffs_reference"]
+
+                calibration[key] = stereo_dict
+            except ValueError as ve:  # maybe could keep going here instead for partial calibration?
+                raise ValueError(f"Failed to calibrate pair {pair} : {ve}")
+
+    return calibration
+
+
+def detect_charuco_corners(
+    img: np.ndarray,
+    charuco_board: cv2.aruco_CharucoBoard = SPOT_DEFAULT_CHARUCO,
+    aruco_dict: cv2.aruco_Dictionary = SPOT_DEFAULT_ARUCO_DICT,
+) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    """
+    Detect the Charuco Corners and their IDs in an image.
+
+    Args:
+        img (np.ndarray): The image to find charuco corners in
+        charuco_board (cv2.aruco_CharucoBoard, optional): What
+            charuco board to look for. Defaults to SPOT_DEFAULT_CHARUCO.
+        aruco_dict (cv2.aruco_Dictionary, optional): What aruco dict to look for.
+        Defaults to SPOT_DEFAULT_ARUCO_DICT.
+
+    Returns:
+        Tuple[Optional[np.ndarray], Optional[np.ndarray]]: Either the corners, and their
+        ids, or (None,None) if corners weren't found.
+    """
+    if len(img.shape) == 2:
+        gray = img
+    else:
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+    corners, ids, _ = cv2.aruco.detectMarkers(gray, aruco_dict)
+    if ids is not None:
+        """
+        Here, setting the minMarkers=0 flag is critical for a good calibration due to the partial
+        board views. Otherwise, no corners near the border of the board are used, which with the
+        large default spot board, results in no points near the border of the image being collected.
+        Without points near the border of the image, the distortion model will be inaccurate.
+        """
+        _, charuco_corners, charuco_ids = cv2.aruco.interpolateCornersCharuco(
+            corners, ids, gray, charuco_board, minMarkers=0
+        )
+
+        return charuco_corners, charuco_ids
+    return None, None
+
+
+def get_charuco_board_object_points(
+    charuco_board: cv2.aruco_CharucoBoard,
+    corners_ids: Union[List, np.ndarray],
+) -> np.ndarray:
+    """
+    From a charuco board, and corner ids, generate the object points for use
+    in a calibration sequence to solve the perspective and point problem.
+
+    Args:
+        charuco_board (cv2.aruco_CharucoBoard): the charuco board
+            to generate object points for
+        corners_ids (Union[List, np.ndarray]): which corner ids to generate points for
+
+    Returns:
+        np.ndarray: the object points
+    """
+    object_points = []
+    for idx in corners_ids:
+        object_points.append(charuco_board.chessboardCorners[idx])
+    return np.array(object_points, dtype=np.float32)
+
+
+def calibrate_single_camera_charuco(
+    images: List[np.ndarray],
+    charuco_board: cv2.aruco_CharucoBoard = SPOT_DEFAULT_CHARUCO,
+    aruco_dict: cv2.aruco_Dictionary = SPOT_DEFAULT_ARUCO_DICT,
+    debug_str: str = "",
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Calibrate a monocular camera from a charuco board.
+
+    Args:
+        images (List[np.ndarray]): A list of images of the board
+        charuco_board (cv2.aruco_CharucoBoard, optional): which
+            board to look for in the images. Defaults to SPOT_DEFAULT_CHARUCO.
+        aruco_dict (cv2.aruco_Dictionary, optional): which
+            aruco dict to look for in the images. Defaults to SPOT_DEFAULT_ARUCO_DICT.
+        debug_str (str, optional): what to add to the logging
+            to differentiate this monocular calibration from others, for the sake
+            of stereo calibrations. Defaults to "".
+
+    Raises:
+        ValueError: Not enough data to calibrate
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: the camera matrix and distortion coefficients
+    """
+    all_corners = []
+    all_ids = []
+    img_size = None
+
+    for idx, img in enumerate(images):
+        if img_size is None:
+            img_size = img.shape[:2][::-1]
+
+        charuco_corners, charuco_ids = detect_charuco_corners(img, charuco_board, aruco_dict)
+
+        if charuco_corners is not None and len(charuco_corners) >= 8:
+            all_corners.append(charuco_corners)
+            all_ids.append(charuco_ids)
+        else:
+            logger.warning(f"Not enough corners detected in image index {idx} {debug_str}; ignoring")
+
+    if len(all_corners) > 1:
+        obj_points_all = []
+        img_points = []
+        for corners, ids in zip(all_corners, all_ids):
+            obj_points = get_charuco_board_object_points(charuco_board, ids)
+            obj_points_all.append(obj_points)
+            img_points.append(corners)
+        logger.info(f"About to process {len(obj_points_all)} points for single camera cal | {debug_str}")
+        # Long term improvement: could pull tvec for use to localize camera relative to robot?
+        _, camera_matrix, dist_coeffs, _, _ = cv2.calibrateCamera(  # use LU flag critical for speed
+            obj_points_all,
+            img_points,
+            img_size,
+            None,
+            None,
+            flags=cv2.CALIB_USE_LU,
+        )
+
+        return camera_matrix, dist_coeffs
+    else:
+        raise ValueError(f"Not enough valid points to individually calibrate {debug_str}")
+
+
+def stereo_calibration_charuco(
+    origin_images: List[np.ndarray],
+    reference_images: List[np.ndarray],
+    charuco_board: cv2.aruco_CharucoBoard = SPOT_DEFAULT_CHARUCO,
+    aruco_dict: cv2.aruco_Dictionary = SPOT_DEFAULT_ARUCO_DICT,
+    camera_matrix_origin: Optional[np.ndarray] = None,
+    dist_coeffs_origin: Optional[np.ndarray] = None,
+    camera_matrix_reference: Optional[np.ndarray] = None,
+    dist_coeffs_reference: Optional[np.ndarray] = None,
+) -> Dict:
+    """
+    Perform a stereo calibration from a set of syncrhonized stereo images of a charuco calibration
+    board.
+
+    Args:
+        origin_images (List[np.ndarray]): A list of images synced to reference images from camera 0
+        reference_images (List[np.ndarray]): A list of images synced to origin images from camera 1
+        charuco_board (cv2.aruco_CharucoBoard, optional): What charuco board to
+            use for the cal. Defaults to SPOT_DEFAULT_CHARUCO.
+        aruco_dict (cv2.aruco_Dictionary, optional): What aruco board to use for the cal.
+            Defaults to SPOT_DEFAULT_ARUCO_DICT.
+        camera_matrix_origin (Optional[np.ndarray], optional): What camera
+            matrix to assign to camera 0. If none, is computed. Defaults to None.
+        dist_coeffs_origin (Optional[np.ndarray], optional): What distortion coefficients
+            to assign to camera 0. If None, is computed. Defaults to None.
+        camera_matrix_reference (Optional[np.ndarray], optional): What camera
+            matrix to assign to camera 1. If none, is computed. . Defaults to None.
+        dist_coeffs_reference (Optional[np.ndarray], optional): What distortion coefficients
+            toa ssign to camera 1. If None, is computed. Defaults to None.
+
+    Raises:
+        ValueError: Could not calibrate a camera individually
+        ValueError: Not enough points to stereo calibrate
+        ValueError: Could not stereo calibrate
+
+    Returns:
+        Dict: _description_
+    """
+    if camera_matrix_origin is None or dist_coeffs_origin is None:
+        logger.info("Calibrating Origin Camera individually")
+        camera_matrix_origin, dist_coeffs_origin = calibrate_single_camera_charuco(
+            images=origin_images,
+            charuco_board=charuco_board,
+            aruco_dict=aruco_dict,
+            debug_str="for origin camera",
+        )
+    if camera_matrix_reference is None or dist_coeffs_origin is None:
+        logger.info("Calibrating reference Camera individually ")
+        camera_matrix_reference, dist_coeffs_reference = calibrate_single_camera_charuco(
+            images=reference_images,
+            charuco_board=charuco_board,
+            aruco_dict=aruco_dict,
+            debug_str="for reference camera",
+        )
+
+    if camera_matrix_origin is None or camera_matrix_reference is None:
+        raise ValueError("Could not calibrate one of the cameras as desired")
+
+    all_corners_origin = []
+    all_corners_reference = []
+    all_ids_origin = []
+    all_ids_reference = []
+    img_size = None
+
+    for origin_img, reference_img in zip(origin_images, reference_images):
+        if img_size is None:
+            img_size = origin_img.shape[:2][::-1]
+
+        origin_charuco_corners, origin_charuco_ids = detect_charuco_corners(origin_img, charuco_board, aruco_dict)
+        reference_charuco_corners, reference_charuco_ids = detect_charuco_corners(
+            reference_img, charuco_board, aruco_dict
+        )
+
+        if origin_charuco_corners is not None and reference_charuco_corners is not None:
+            all_corners_origin.append(origin_charuco_corners)
+            all_corners_reference.append(reference_charuco_corners)
+            all_ids_origin.append(origin_charuco_ids)
+            all_ids_reference.append(reference_charuco_ids)
+
+    if len(all_corners_origin) > 0:
+        obj_points_all = []
+        img_points_origin = []
+        img_points_reference = []
+        for (
+            origin_corners,
+            reference_corners,
+            origin_ids,
+            reference_ids,
+        ) in zip(
+            all_corners_origin,
+            all_corners_reference,
+            all_ids_origin,
+            all_ids_reference,
+        ):
+            common_ids = np.intersect1d(origin_ids, reference_ids)
+            if len(common_ids) >= 6:  # Ensure there are at least 6 points
+                obj_points = get_charuco_board_object_points(charuco_board, common_ids)
+                obj_points_all.append(obj_points)
+                img_points_origin.append(origin_corners[np.isin(origin_ids, common_ids)])
+                img_points_reference.append(reference_corners[np.isin(reference_ids, common_ids)])
+
+        if len(obj_points_all) > 0:
+            logger.info(f"Collected {len(obj_points_all)} shared point sets for stereo calibration.")
+            _, _, _, _, _, R, T, E, F = cv2.stereoCalibrate(
+                obj_points_all,
+                img_points_origin,
+                img_points_reference,
+                camera_matrix_origin,
+                dist_coeffs_origin,
+                camera_matrix_reference,
+                dist_coeffs_reference,
+                img_size,
+                criteria=(
+                    cv2.TERM_CRITERIA_MAX_ITER + cv2.TERM_CRITERIA_EPS,
+                    100,
+                    1e-6,
+                ),
+                flags=cv2.CALIB_USE_LU,
+            )
+            logger.info("Stereo calibration completed.")
+
+            return {
+                "dist_coeffs_origin": dist_coeffs_origin,
+                "camera_matrix_origin": camera_matrix_origin,
+                "image_dim_origin": np.array(origin_images[0].shape[:2]),
+                "dist_coeffs_reference": dist_coeffs_reference,
+                "camera_matrix_reference": camera_matrix_reference,
+                "image_dim_reference": np.array(reference_images[0].shape[:2]),
+                "R": R,
+                "T": T,
+            }
+        else:
+            raise ValueError("Not enough valid points for stereo calibration.")
+    else:
+        raise ValueError("Not enough shared points for stereo calibration.")
+
+
+def est_camera_t_charuco_board_center(
+    img: np.ndarray,
+    charuco_board: cv2.aruco_CharucoBoard,
+    aruco_dict: cv2.aruco_Dictionary,
+    camera_matrix: np.ndarray,
+    dist_coeffs: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Localizes the 6D pose of the checkerboard center using Charuco corners.
+
+    The board pose's translation should be at the center of the board, with the orientation
+    in OpenCV format, where the +Z points out of the board with
+    the other axis being parallel to the sides of the board.
+
+    Args:
+        img (np.ndarray): The input image containing the checkerboard.
+        charuco_board (cv2.aruco_CharucoBoard): The Charuco board configuration.
+        aruco_dict (cv2.aruco_Dictionary): The Aruco dictionary used to detect markers.
+        camera_matrix (np.ndarray): The camera matrix from calibration.
+        dist_coeffs (np.ndarray): The distortion coefficients from calibration.
+
+    Returns:
+        Optional[Tuple[np.ndarray, np.ndarray]]: The rotation vector and translation vector
+        representing the 6D pose of the checkerboard center if found, else None.
+    """
+    charuco_corners, charuco_ids = detect_charuco_corners(img, charuco_board, aruco_dict)
+
+    if charuco_corners is not None and charuco_ids is not None:
+        # Estimate the pose of the Charuco board
+        rvec = np.zeros((3, 1))
+        tvec = np.zeros((3, 1))
+        retval, rvec, tvec = cv2.aruco.estimatePoseCharucoBoard(
+            charuco_corners,
+            charuco_ids,
+            charuco_board,
+            camera_matrix,
+            dist_coeffs,
+            rvec,
+            tvec,
+        )
+        if retval:
+            # Compute the translations needed to transform to the center
+            x_trans = (charuco_board.getSquareLength() * charuco_board.getChessboardSize()[0]) / 2.0
+            y_trans = (charuco_board.getSquareLength() * charuco_board.getChessboardSize()[1]) / 2.0
+            # Adjust tvec to be relative to the center
+            center_trans = np.array([x_trans, y_trans, 0.0]).reshape((3, 1))
+            rmat, _ = cv2.Rodrigues(rvec)
+            tvec = tvec + rmat.dot(center_trans)
+
+            return np.array(rmat), np.array(tvec).ravel()
+        else:
+            raise ValueError(
+                "Corners were found, but failed to localize. You likely primed the robot too close to the board"
+            )
+    else:
+        raise ValueError(
+            "Couldn't detect any Charuco Boards in the image, "
+            "localization failed. Ensure the board is visible from the"
+            " primed pose."
+        )
+
+
+def convert_camera_t_viewpoint_to_origin_t_planning_frame(
+    origin_t_planning_frame: np.ndarray = np.eye(4),
+    planning_frame_t_opencv_camera: np.ndarray = np.eye(4),
+    opencv_camera_t_viewpoint: np.ndarray = np.eye(4),
+) -> np.ndarray:
+    """
+    Convert a camera viewpoint given in a camera frame, to the planning frame.
+
+    Camera frame should be in OpenCV/ ROS format, where
+    +x should point to the right in the image
+    +y should point down in the image
+    +z should point into to plane of the image.
+
+    Assuming that origin_t_planning_frame isn't aligned with this format, align it
+    so that the viewpoint can be localized as a hand pose command.
+
+    Args:
+        origin_t_planning_frame (np.ndarray, optional): 4x4 homogenous transform
+            from origin to planning frame. Defaults to np.eye(4).
+        planning_frame_t_opencv_camera (np.ndarray, optional): 4x4 homogenous transform
+            from planning frame to the camera. Defaults to np.eye(4).
+        opencv_camera_t_viewpoint (np.ndarray, optional): 4x4 homogenous transform
+            from camera to the future viewpoint. Defaults to np.eye(4).
+
+    Returns:
+        np.ndarray: 4x4 homogenous transform of origin to planning frame of future viewpoint.
+    """
+    origin_t_opencv_camera_pose = origin_t_planning_frame @ planning_frame_t_opencv_camera
+    origin_t_viewpoint = origin_t_opencv_camera_pose @ opencv_camera_t_viewpoint
+    origin_t_planning_frame_next = origin_t_viewpoint @ np.linalg.inv(planning_frame_t_opencv_camera)
+    return origin_t_planning_frame_next
+
+
+def get_relative_viewpoints_from_board_pose_and_param(
+    R_board: np.ndarray,
+    tvec: np.ndarray,
+    distances: np.ndarray = np.arange(0.5, 0.7, 0.1),
+    x_axis_rots: np.ndarray = np.arange(-20, 21, 5),
+    y_axis_rots: np.ndarray = np.arange(-20, 21, 5),
+    z_axis_rots: np.ndarray = np.array([-20, 21, 5]),
+    R_align_board_frame_with_camera: np.ndarray = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]]),
+    degree_offset_rotations: bool = True,
+) -> List[np.ndarray]:
+    """
+    Given the position of charuco board, sample viewpoints facing the calibration board for
+    the robot's "principal" camera to visit. When the robot moves to these viewpoints,
+    it takes synchronized photos with all cameras to use for solving the calibration.
+
+    ROS and OpenCV have the same camera format, where:
+        # +x should point to the right in the image
+        # +y should point down in the image
+        # +z should point into to plane of the image.
+
+    All transforms to cameras are in this format.
+
+    Args:
+        R_board (np.ndarray): the rotation of the calibration board in opencv notation relative
+            to the "principal" camera.
+            (See AutomaticCameraCalibration.localize_target_to_principal_camera)
+        tvec (np.ndarray): the translation of the calibration board in opencv notation relative to
+            the principal camera
+        distances (np.ndarray, optional): What distances
+            away from the calibration board's pose (along the Z axis)
+            to sample calibration viewpoints from. Defaults to np.arange(0.5, 0.8, 0.1).
+        x_axis_rots (np.ndarray, optional): What
+            x-axis rotations relative to the camera viewing the board orthogonally
+            to apply to sample viewpoints. Defaults to np.arange(-21, 21, 5).
+        y_axis_rots (np.ndarray, optional): What
+            y-axis rotations relative to the camera viewing the board orthogonally
+            to apply to sample viewpoints. Defaults to np.arange(-21, 21, 5).
+        z_axis_rots (np.ndarray, optional): What
+            z-axis rotations relative to the camera viewing the board orthogonally
+            to apply to sample viewpoints. Defaults to np.array([-21, 21, 5]).
+        R_align_board_frame_with_camera (np.ndarray, optional): By default,
+            the charuco pose rotation Z-axis points out of the pattern,
+            and into the camera. However, to sample viewpoints, the camera must face the board,
+            so viewpoints can't be sampled directly from the board pose as they would face
+            away from the board.
+            This rotates the board frame such that the Z axis points away
+            from the pattern, so that camera frames facing the board may be sampled
+            after applying a distance and offset rotation.
+            Defaults to np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]]).
+        degree_offset_rotations (bool, optional): whether to use degree for the
+            sampling rotation parameters. Defaults to True.
+
+    Returns:
+        List[np.ndarray]: a list of 4x4 homogenous transforms to visit in the "principal" cameras
+            frame
+    """
+    if degree_offset_rotations:
+        x_axis_rots = [radians(deg) for deg in x_axis_rots]
+        y_axis_rots = [radians(deg) for deg in y_axis_rots]
+        z_axis_rots = [radians(deg) for deg in z_axis_rots]
+    translations = [tvec + R_board[:, 2] * dist for dist in distances]
+    R_base = R_board @ R_align_board_frame_with_camera
+
+    def euler_to_rotation_matrix(roll: float, pitch: float, yaw: float) -> np.ndarray:
+        """
+        Convert Euler angles to a rotation matrix using OpenCV, for the sake
+        of CLI convenience, conciseness, while not depending on an external transform lib.
+        """
+        R_x = cv2.Rodrigues(np.array([roll, 0, 0]))[0]
+        R_y = cv2.Rodrigues(np.array([0, pitch, 0]))[0]
+        R_z = cv2.Rodrigues(np.array([0, 0, yaw]))[0]
+        return R_z @ R_y @ R_x
+
+    poses = []
+    for t in translations:
+        for x_axis_rot in x_axis_rots:
+            for y_axis_rot in y_axis_rots:
+                for z_axis_rot in z_axis_rots:
+                    # Get the rotation matrix from Euler angles
+                    R_rot = euler_to_rotation_matrix(x_axis_rot, y_axis_rot, z_axis_rot)
+
+                    # Combine with the base rotation
+                    R_base_modified = R_base @ R_rot
+
+                    transform = np.eye(4)
+                    transform[:-1, -1] = t.reshape((3,))
+                    transform[:-1, :-1] = R_base_modified
+                    poses.append(transform)
+
+    logger.info(f"Calculated {len(poses)} relative viewpoints to visit relative to the target.")
+    return poses
+
+
+def create_calibration_save_folders(path: str, num_folders: int) -> None:
+    """
+    Create a folder hierarchy to record a calibration
+
+    Args:
+        path (str): The parent path
+        num_folders (int): How many cameras, a.k.a how many folder to create
+
+    Raises:
+        ValueError: Not possible to create the folders, or no path specified
+    """
+    if path is None:
+        raise ValueError("No path to save to :(")
+    else:
+        for idx in range(num_folders):
+            cam_path = os.path.join(path, str(idx))
+
+            logger.info(f"Creating image folder at {cam_path}")
+            os.makedirs(cam_path, exist_ok=True)
+        logger.info(f"Done creating {num_folders} folders.")
+
+
+def load_images_from_path(path: str) -> np.ndarray:
+    """
+    Load image dataset from path in a way that's compatible with multistereo_calibration_charuco.
+
+    Args:
+        path (str): The parent path
+
+    Raises:
+        ValueError: Not possible to load the images
+
+    Returns:
+        np.ndarray: The image dataset
+    """
+    # List all directories within the given path and sort them
+    dirs = [d for d in os.listdir(path) if os.path.isdir(os.path.join(path, d))]
+    if len(dirs) == 0:
+        raise ValueError("No sub-dirs found in datapath from which to load images.")
+    dirs = sorted(dirs, key=lambda x: int(x))  # Assuming dir names are integers like "0", "1", etc.
+
+    # Initialize an empty list to store images
+    images = []
+
+    for dir_name in dirs:
+        # Construct the glob pattern for the images in the current directory
+        pic_path_match = os.path.join(path, dir_name, "*")
+        # Get a sorted list of image files based on the numerical order in their filenames
+        image_files = sorted(
+            glob(pic_path_match),
+            key=lambda x: int(re.search(r"(\d+)(?=\D*$)", x).group()),
+        )
+        # Read images and store them
+        images.append([cv2.imread(fn) for fn in image_files])
+
+    # Convert the list of lists into a NumPy array
+    # The array shape will be (number_of_images, number_of_directories)
+    images = np.array(images, dtype=object)
+
+    # Transpose the array so that you can access it as images[:, axis]
+    images = np.transpose(images, (1, 0))
+
+    return images
+
+
+def save_calibration_parameters(
+    data: Dict,
+    output_path: str,
+    num_images: int,
+    tag: str,
+    parser_args: Optional[argparse.Namespace] = None,
+    unsafe: bool = False,
+) -> None:
+    """
+    Dump the results of a calibration, and the metadata associated with the command that
+    created it, to a file
+
+    Args:
+        data (Dict): The results of the calibration
+        output_path (str): The path/name of what to create
+        num_images (int): How many images were used for this calibration
+        tag (str): What tag to give as the heading/name for this calibration
+        parser_args (Optional[argparse.Namespace], optional): The args that were
+            used to create the calibration. Defaults to None.
+        unsafe (bool, optional): Whether to overwrite existing calibrations of the same name,
+            and to ignore recommended naming scheme. Defaults to False.
+    """
+
+    def flatten_matrix(matrix: np.ndarray) -> List:
+        return matrix.flatten().tolist()
+
+    def process_data_with_nested_dictionaries(
+        data: Dict,
+    ) -> Tuple[Dict, Dict]:
+        cameras = {}
+        relations = {}
+
+        for key, value in data.items():
+            origin_cam, reference_cam = int(key.split("_")[0]), int(key.split("_")[1])
+
+            # Process origin camera data
+            if origin_cam not in cameras:
+                cameras[origin_cam] = {
+                    "camera_matrix": flatten_matrix(value["camera_matrix_origin"]),
+                    "dist_coeffs": flatten_matrix(value["dist_coeffs_origin"]),
+                    "image_dim": flatten_matrix(value["image_dim_origin"]),
+                }
+
+            # Process reference camera data
+            if reference_cam not in cameras:
+                cameras[reference_cam] = {
+                    "camera_matrix": flatten_matrix(value["camera_matrix_reference"]),
+                    "dist_coeffs": flatten_matrix(value["dist_coeffs_reference"]),
+                    "image_dim": flatten_matrix(value["image_dim_reference"]),
+                }
+
+            # Store the rotation and translation in a nested dictionary structure
+            if origin_cam not in relations:
+                relations[origin_cam] = {}
+            relations[origin_cam][reference_cam] = {
+                "R": flatten_matrix(value["R"]),
+                "T": flatten_matrix(value["T"]),
+            }
+
+        return cameras, relations
+
+    # Handle empty or missing tag
+    if not tag:
+        tag = "default"
+
+    # Load existing YAML file if it exists
+    output_path = os.path.expanduser(output_path)
+    if os.path.exists(output_path):
+        with open(output_path, "r") as file:
+            existing_data = yaml.safe_load(file) or {}
+    else:
+        existing_data = {}
+
+    # Check for overwriting existing tag
+    if not unsafe:
+        overwrite_confirmed = False
+        while not overwrite_confirmed:
+            if tag in existing_data:
+                sure = input(f"Tag '{tag}' already exists. Overwrite existing calibration (y/n)? ").strip().lower()
+                if sure == "y":
+                    logger.warning(f"Overwriting the existing tag '{tag}' in {output_path}.")
+                    overwrite_confirmed = True
+                elif sure == "n":
+                    tag = input("Enter a new tag: ").strip() or "default"
+                    if tag not in existing_data:
+                        overwrite_confirmed = True
+            elif not existing_data and tag != "default":
+                sure = (
+                    input(
+                        "The file is empty. It is recommended to use "
+                        "the default tag. Are you sure you want to use"
+                        f" '{tag}' instead? (y/n): "
+                    )
+                    .strip()
+                    .lower()
+                )
+                if sure == "y":
+                    overwrite_confirmed = True
+                elif sure == "n":
+                    tag = "default"
+                    overwrite_confirmed = True
+            else:
+                overwrite_confirmed = True
+
+    # Process the new calibration data
+    cameras, relations = process_data_with_nested_dictionaries(data)
+
+    # Prepare the output data under the specified tag
+    tagged_data = {
+        "intrinsic": cameras,
+        "extrinsic": relations,
+        "run_param": {},
+    }
+    tagged_data["run_param"]["num_images"] = num_images
+    tagged_data["run_param"]["timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    # Include parser parameters, excluding 'password' and 'username'
+    if parser_args is not None:
+        for arg in vars(parser_args):
+            if arg not in ["password", "username", "result_path"]:
+                tagged_data["run_param"][arg] = getattr(parser_args, arg)
+    else:
+        logger.warning("Saving calibration, but not the parameters used to obtain it.")
+
+    # Convert any tuples in run_param (like stereo_pairs) to lists
+    if "stereo_pairs" in tagged_data["run_param"]:
+        tagged_data["run_param"]["stereo_pairs"] = [list(pair) for pair in tagged_data["run_param"]["stereo_pairs"]]
+
+    # Save the updated data under the specified tag
+    existing_data[tag] = tagged_data
+
+    # Ensure the directory exists
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    # Save to YAML file
+    with open(output_path, "w") as file:
+        yaml.dump(
+            existing_data,
+            file,
+            default_flow_style=None,
+            sort_keys=False,
+        )
+    logger.info(f"Saved calibration to file {output_path} under tag '{tag}'")

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -610,7 +610,8 @@ def convert_camera_t_viewpoint_to_origin_t_planning_frame(
             from camera to the future viewpoint. Defaults to np.eye(4).
 
     Returns:
-        np.ndarray: 4x4 homogenous transform of origin to planning frame of future viewpoint.
+        np.ndarray: 4x4 homogenous transform of the planning frame of a future viewpoint
+            expressed in the origin frame.
     """
     origin_t_opencv_camera_pose = origin_t_planning_frame @ planning_frame_t_opencv_camera
     origin_t_viewpoint = origin_t_opencv_camera_pose @ opencv_camera_t_viewpoint

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -1,0 +1,291 @@
+# Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
+
+import logging
+from typing import List, Optional, Tuple, Union
+
+import cv2
+import numpy as np
+from bosdyn.api import estop_pb2, gripper_camera_param_pb2
+from bosdyn.client import create_standard_sdk, math_helpers
+from bosdyn.client.estop import (
+    EstopClient,
+    EstopEndpoint,
+    EstopKeepAlive,
+    MotorsOnError,
+)
+from bosdyn.client.frame_helpers import (
+    BODY_FRAME_NAME,
+    HAND_FRAME_NAME,
+    get_a_tform_b,
+)
+from bosdyn.client.gripper_camera_param import GripperCameraParamClient
+from bosdyn.client.image import ImageClient, build_image_request
+from bosdyn.client.lease import (
+    LeaseClient,
+    LeaseKeepAlive,
+    ResourceAlreadyClaimedError,
+)
+from bosdyn.client.robot_command import (
+    RobotCommandBuilder,
+    RobotCommandClient,
+    block_until_arm_arrives,
+    blocking_sit,
+    blocking_stand,
+)
+from bosdyn.client.robot_state import RobotStateClient
+
+from spot_wrapper.calibration.automatic_camera_calibration_robot import (
+    AutomaticCameraCalibrationRobot,
+)
+from spot_wrapper.calibration.calibration_util import (
+    convert_camera_t_viewpoint_to_origin_t_planning_frame,
+    est_camera_t_charuco_board_center,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+)
+
+logger = logging.getLogger(__name__)
+SPOT_DEFAULT_ARUCO_DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
+SPOT_DEFAULT_CHARUCO = cv2.aruco.CharucoBoard_create(9, 4, 0.115, 0.09, SPOT_DEFAULT_ARUCO_DICT)
+
+
+class SpotInHandCalibration(AutomaticCameraCalibrationRobot):
+    def __init__(self, ip: str, username: str, password: str):
+        """
+        Calibrated intrinsic used to localize the board once in
+        localize_target_to_start_pose_vision . If the board is placed at a known location
+        relative to the arm, then there is no need to do this visually, and thus
+        no need to estimate intrinsic parameters prior to calibration.
+        """
+        logger.info("Connecting to robot...")
+        sdk = create_standard_sdk("SpotSDK")
+        if ip is None or username is None or password is None:
+            raise AttributeError("Must specify IP, username, and password for calibration.")
+        self.robot = sdk.create_robot(ip)
+        self.robot.authenticate(username, password)
+        self.robot.time_sync.wait_for_sync()
+        logger.info("Established time sync, resetting e-stop...")
+        estop_client = self.robot.ensure_client(EstopClient.default_service_name)
+        estop_endpoint = EstopEndpoint(client=estop_client, estop_timeout=20, name="my_estop")
+        try:
+            estop_endpoint.force_simple_setup()
+        except MotorsOnError:
+            raise ValueError(
+                f"You need to disconnect from the robot, cannot setup estop while motors on {MotorsOnError}"
+            )
+        estop_keepalive = EstopKeepAlive(estop_endpoint)
+        estop_keepalive.allow()
+        logger.info("E-Stop is reset and robot is allowed to operate")
+        client = self.robot.ensure_client(EstopClient.default_service_name)
+        if client.get_status().stop_level != estop_pb2.ESTOP_LEVEL_NONE:
+            error_message = "Robot is estopped. Use an external E-Stop client, such as the controller to undo"
+            self.robot.logger.error(error_message)
+            raise Exception(error_message)
+        logger.info("Succesfuly reset estop.")
+        if not self.robot.has_arm():
+            raise ValueError("Could not find an arm to use for the hand calibration.")
+        self.lease_client = self.robot.ensure_client(LeaseClient.default_service_name)
+        self.image_client = self.robot.ensure_client(ImageClient.default_service_name)
+        self.robot_state_client = self.robot.ensure_client(RobotStateClient.default_service_name)
+        self.command_client = self.robot.ensure_client(RobotCommandClient.default_service_name)
+        try:
+            self.keep_alive_leave = LeaseKeepAlive(
+                self.lease_client,
+                must_acquire=True,
+                return_at_exit=True,
+            )
+        except ResourceAlreadyClaimedError as e:
+            raise ValueError(f"Must relinquish control from robot before running calib: {e}")
+
+        self.image_requests = [
+            build_image_request("hand_color_image", quality_percent=100),
+            build_image_request("hand_image", quality_percent=100),
+        ]
+        # Create a GripperCameraParamsClient
+        self.gripper_camera_client = self.robot.ensure_client(GripperCameraParamClient.default_service_name)
+
+    def capture_images(
+        self,
+        encodings: Optional[List[int]] = None,
+    ) -> Union[List, np.ndarray]:
+        if encodings is None:
+            encodings = [cv2.IMREAD_COLOR, cv2.IMREAD_GRAYSCALE]
+        images = []
+        image_responses = self.image_client.get_image(self.image_requests)
+
+        if image_responses:
+            if len(encodings) != len(image_responses):
+                raise ValueError("Need to specify an encoding for each image request")
+            for idx, (response, encoding) in enumerate(zip(image_responses, encodings)):
+                image_data = response.shot.image.data
+                image_data = np.frombuffer(image_data, np.uint8)
+                image_data = cv2.imdecode(image_data, encoding)
+                images.append(image_data)
+        else:
+            raise ValueError(f"Could not obtain desired images {self.image_requests}")
+
+        return np.array(images, dtype=object)
+
+    def localize_target_to_principal_camera(self, images: Union[List, np.ndarray]) -> Tuple[np.ndarray, np.ndarray]:
+        try:
+            return est_camera_t_charuco_board_center(
+                images[0],
+                self.charuco_board,
+                self.aruco_dict,
+                self.estimated_camera_matrix,
+                self.estimated_camera_distort_coeffs,
+            )
+        except AttributeError:
+            raise ValueError("Must call _set_localization_param prior to localizing")
+
+    def move_cameras_to_see_calibration_target(self) -> np.ndarray:
+        def adjust_standing_height(height: float) -> None:
+            stand_command = RobotCommandBuilder.synchro_stand_command(body_height=height)
+            self.command_client.robot_command(stand_command)
+            logger.info(f"Robot standing height adjusted by {height} meters.")
+
+        logger.info("Powering on robot")
+        self.robot.power_on(timeout_sec=20)
+        logger.info("About to open claw, stand, and ready arm to collect calibration set")
+        claw_open_command = RobotCommandBuilder.claw_gripper_open_command()
+        self.command_client.robot_command(claw_open_command)
+        blocking_stand(self.command_client)
+        adjust_standing_height(height=-0.2)
+        ready_arm_command = RobotCommandBuilder.arm_ready_command()
+        ready_id = self.command_client.robot_command(ready_arm_command)
+        block_until_arm_arrives(self.command_client, ready_id)
+        logger.info("Robot in ready position for calibration dataset")
+        logger.info("About to lower arm to see board better...")
+        transform_offset = np.eye(4)
+        transform_offset[:-1, -1] = np.array([0.0, 0.3, -0.2]).reshape((3,))
+        old_pose, ready_pose = self.offset_cameras_from_current_view(transform_offset=transform_offset)
+        return ready_pose
+
+    def offset_cameras_from_current_view(
+        self,
+        transform_offset: np.ndarray,
+        origin_t_planning_frame: Optional[np.ndarray] = None,
+        use_body: bool = False,
+        duration_sec: float = 1.0,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        def grab_state_as_transform() -> np.ndarray:
+            robot_state = self.robot_state_client.get_robot_state()
+            origin_t_planning_frame = get_a_tform_b(
+                robot_state.kinematic_state.transforms_snapshot,
+                BODY_FRAME_NAME,
+                HAND_FRAME_NAME,
+            )
+            pose_transform = np.eye(4)
+            pose_transform[:-1, -1] = np.array(
+                [
+                    origin_t_planning_frame.x,
+                    origin_t_planning_frame.y,
+                    origin_t_planning_frame.z,
+                ]
+            ).reshape((3,))
+            pose_transform[:-1, :-1] = origin_t_planning_frame.rot.to_matrix()
+            return pose_transform
+
+        if origin_t_planning_frame is None:
+            initial_pose = grab_state_as_transform()
+        else:
+            initial_pose = origin_t_planning_frame
+
+        try:
+            opencv_camera_t_viewpoint = np.eye(4)
+            opencv_camera_t_viewpoint[:3, :3] = self.hand_t_opencv_camera_rot
+        except AttributeError:
+            raise ValueError("Must call _set_localization_param prior to invoking this method.")
+        new_pose = convert_camera_t_viewpoint_to_origin_t_planning_frame(
+            origin_t_planning_frame=initial_pose,
+            planning_frame_t_opencv_camera=opencv_camera_t_viewpoint,
+            opencv_camera_t_viewpoint=transform_offset,
+        )
+
+        new_pose_quat = math_helpers.Quat.from_matrix(new_pose[:-1, :-1])
+
+        new_arm_command = RobotCommandBuilder.arm_pose_command(
+            new_pose[0, 3],  # x
+            new_pose[1, 3],  # y
+            new_pose[2, 3],  # z
+            new_pose_quat.w,
+            new_pose_quat.x,
+            new_pose_quat.y,
+            new_pose_quat.z,
+            BODY_FRAME_NAME,
+            duration_sec,
+        )
+        if not use_body:
+            command_id = self.command_client.robot_command(new_arm_command)
+        else:
+            follow_arm_command = RobotCommandBuilder.follow_arm_command()
+            command = RobotCommandBuilder.build_synchro_command(follow_arm_command, new_arm_command)
+            command_id = self.command_client.robot_command(command)
+        block_until_arm_arrives(
+            self.command_client,
+            command_id,
+            timeout_sec=duration_sec * 2,
+        )
+
+        return (initial_pose, new_pose)  # second value is new value
+
+    def shutdown(self) -> None:
+        stow_arm_command = RobotCommandBuilder.arm_stow_command()
+        ready_id = self.command_client.robot_command(stow_arm_command)
+        block_until_arm_arrives(self.command_client, ready_id)
+        blocking_sit(self.command_client)
+        self.keep_alive_leave.shutdown()
+        logger.info("IT IS NOW SAFE TO RETAKE CONTROL OF SPOT, DONE TAKING PICS :)")
+
+    def _set_localization_param(
+        self,
+        charuco_board: cv2.aruco_CharucoBoard,
+        aruco_dict: cv2.aruco_Dictionary,
+        resolution: Tuple[int, int] = (
+            640,
+            480,
+        ),  # (1920, 1080),#(640, 480),
+        hand_t_opencv_camera_rot: np.ndarray = np.array(
+            [
+                [0.00, 0.00, 1.00],
+                [-1.00, 0.00, 0.00],
+                [0.00, -1.00, 0.00],
+            ]
+        ),
+    ) -> None:
+        self.resolution = resolution
+
+        gripper_camera_params = gripper_camera_param_pb2.GripperCameraParamRequest()
+        if resolution == (640, 480):
+            camera_matrix_est = np.array(  # hard coded for initial localization
+                [
+                    [540.70883089, 0.0, 322.53051396],
+                    [0.0, 540.45766656, 236.25863472],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+            gripper_camera_params.params.camera_mode = 11
+        elif resolution == (1920, 1080):
+            camera_matrix_est: np.ndarray = np.array(
+                [
+                    [1656.0873036483201, 0.0, 960.0],
+                    [0.0, 1656.0873036483201, 540.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+            gripper_camera_params.params.camera_mode = 14
+        else:
+            raise ValueError(f"Unsupported resolution for board localization. {resolution}")
+        logger.info(f"Setting gripper camera resolution to be {resolution}")
+        self.gripper_camera_client.set_camera_params(gripper_camera_params)
+        logger.info(f"Resolution set succesfully to {resolution}")
+        camera_dist_coeffs_est: np.ndarray = np.array([[0.0, 0.0, 0.0, 0.0, 0.0]])
+
+        self.charuco_board = charuco_board
+        self.aruco_dict = aruco_dict
+        self.estimated_camera_matrix = camera_matrix_est
+        self.estimated_camera_distort_coeffs = camera_dist_coeffs_est
+        # this can be obtained with your favorite transform lib like SO3.Eul([0, 90, -90]
+        self.hand_t_opencv_camera_rot = hand_t_opencv_camera_rot

--- a/spot_wrapper/testing/mocks/robot_state.py
+++ b/spot_wrapper/testing/mocks/robot_state.py
@@ -21,6 +21,7 @@ from bosdyn.client.frame_helpers import (
     BODY_FRAME_NAME,
     GRAV_ALIGNED_BODY_FRAME_NAME,
     GROUND_PLANE_FRAME_NAME,
+    HAND_FRAME_NAME,
     ODOM_FRAME_NAME,
     VISION_FRAME_NAME,
 )
@@ -32,10 +33,12 @@ RIGHT_FRAME_NAME = "right"
 FRONT_LEFT_FRAME_NAME = "frontleft"
 FRONT_RIGHT_FRAME_NAME = "frontright"
 BACK_CAMERA_FRAME_NAME = "back_fisheye"
+WRIST_FRAME_NAME = "arm_link_wr1"
 FRONT_LEFT_CAMERA_FRAME_NAME = "frontleft_fisheye"
 FRONT_RIGHT_CAMERA_FRAME_NAME = "frontright_fisheye"
 LEFT_CAMERA_FRAME_NAME = "left_fisheye"
 RIGHT_CAMERA_FRAME_NAME = "right_fisheye"
+HAND_CAMERA_FRAME_NAME = "hand_color_image_sensor"
 
 
 class MockRobotStateService(RobotStateServiceServicer):
@@ -85,6 +88,12 @@ class MockRobotStateService(RobotStateServiceServicer):
         head_to_front_right_edge.parent_tform_child.position.y = -0.2
         head_to_front_right_edge.parent_tform_child.rotation.w = 1.0
 
+        head_to_wrist_edge = transforms_snapshot.child_to_parent_edge_map[WRIST_FRAME_NAME]
+        head_to_wrist_edge.parent_frame_name = HEAD_FRAME_NAME
+        head_to_wrist_edge.parent_tform_child.position.x = 0.2
+        head_to_wrist_edge.parent_tform_child.position.z = 0.5
+        head_to_wrist_edge.parent_tform_child.rotation.w = 1.0
+
         for parent_frame_name, child_frame_name in (
             (ODOM_FRAME_NAME, BODY_FRAME_NAME),
             (BODY_FRAME_NAME, GROUND_PLANE_FRAME_NAME),
@@ -95,6 +104,8 @@ class MockRobotStateService(RobotStateServiceServicer):
             (RIGHT_FRAME_NAME, RIGHT_CAMERA_FRAME_NAME),
             (FRONT_LEFT_FRAME_NAME, FRONT_LEFT_CAMERA_FRAME_NAME),
             (FRONT_RIGHT_FRAME_NAME, FRONT_RIGHT_CAMERA_FRAME_NAME),
+            (WRIST_FRAME_NAME, HAND_FRAME_NAME),
+            (HAND_FRAME_NAME, HAND_CAMERA_FRAME_NAME),
         ):
             edge = transforms_snapshot.child_to_parent_edge_map[child_frame_name]
             edge.parent_frame_name = parent_frame_name


### PR DESCRIPTION
# Change Overview
Related PR for ROS2 Functionality: https://github.com/bdaiinstitute/spot_ros2/pull/455#issue-2474033396

Add a custom automatic calibration routine to allow Spot to calibrate it's own hand cameras. 

# Testing Done
Ran the entire calibration, end-to-end, several times on a few different Spots and calibration boards in Spot lab. Also, ran different calibrations on the same collected datasets.

Note: Open3d is added as a dep so that the republisher in the related PR that shares the same requirements.txt is able to do point cloud to image conversions