### PR TITLE
Calibration fixes: Supporting OpenCV prior to and after breaking changes in 4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ bosdyn-mission==4.0.2
 grpcio==1.59.3
 image==1.5.33
 inflection==0.5.1
+opencv-python>=4.5.4
 open3d==0.18.0 
 protobuf==4.22.1
 pytest==7.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ protobuf==4.22.1
 pytest==7.3.1
 pytest-cov==4.1.0
 pytest-xdist==3.5.0
+pyyaml>=6.0
 setuptools==59.6.0

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -168,8 +168,12 @@ python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_
 ## Improving Calibration Quality
 If you find that the calibration quality isn't high enough, try a longer calibration
 with a wider variety of viewpoints (decrease the step size, increase the bounds). 
-The default calibration viewpoint parameters are meant to facilitate a quick  calibration
+The default calibration viewpoint parameters are meant to facilitate a quick calibration
 even on more inexpensive hardware, and as such uses a minimal amount of viewpoints. 
+
+However, in calibration, less is more. It is better to collect fewer high quality
+viewpoints then many low quality ones. Play with the viewpoint sampling parameters
+to find what takes the most diverse high quality photos of the board.
 
 Also, [make you are checking if your board is legacy, and if you can 
 allow default corner ordering](#check-if-you-have-a-legacy-charuco-board).

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -126,6 +126,12 @@ After the calibration is finished, Spot stows its arm and sits back down. At thi
 it is safe to take control of Spot from the tablet or ROS 2 , even if the calibration script is still
 running. Just don't stop the script or it will stop calculating the parameters :) 
 
+If Spot is shaking while moving the arm around, it is likely that
+your viewpoint range is too close or too far (most often, adjusting
+```--dist_from_board_viewpoint_range``` will help with that). You can
+also try to drive the Spot to a better location to start the calibration
+that fits the distance from viewpoint range better.
+
 ## Example Usage (a.k.a Hand Specific Live Incantations)
 For all possible arguments to the Hand Specific CLI tool, run ```python3 calibrate_spot_hand_camera_cli.py -h```.
 Many parameters are customizable.

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -172,7 +172,10 @@ The default calibration viewpoint parameters are meant to facilitate a quick  ca
 even on more inexpensive hardware, and as such uses a minimal amount of viewpoints. 
 
 Also, [make you are checking if your board is legacy, and if you can 
-allow default corner ordering](#check-if-you-have-a-legacy-charuco-board)
+allow default corner ordering](#check-if-you-have-a-legacy-charuco-board).
+
+If you are using a robot to collect your dataset, such as Spot, increase the settle
+time prior to taking an image (see ```--settle_time```)
 
 ## Using the Registered Information with Spot ROS 2
 If you have the [Spot ROS 2 Driver](https://github.com/bdaiinstitute/spot_ros2) installed,

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -236,7 +236,7 @@ If you like the core tools of this utility, and you'd like a more portable versi
 use independent of Spot that doesn't depend on Spot Wrapper, you could recreate
 the CLI tool with no dependency on Spot Wrapper with the following command:
 ```
-cat calibration_util.py <(tail -n +3 automatic_camera_calibration_robot.py) <(tail -n +21 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
+cat calibration_util.py <(tail -n +3 automatic_camera_calibration_robot.py) <(tail -n +23 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
 ```
 The core capability above depends primarily on NumPy, OpenCV and standard Python libraries.
 

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -58,6 +58,10 @@ list of images obtained with the default cameras (assuming that the new camera
 is fixed relative to the existing cameras.).
 
 # Check if you have a Legacy Charuco Board
+
+You only need to do this if using an opencv version after ```4.7```(
+check with```python3 -c "import cv2; print(cv2.__version__)"```)
+
 Through using the CLI tool (```python3 calibrate_multistereo_cameras_with_charuco_cli.py -h```), you can check if you have a legacy board through visually comparing the generated drawn virtual board to your physical charuco board target. Some legacy boards have an aruco tag in the top
 left corner, whether as some non-legacy boards have a checker in the top left corner.
 Also, check to see that the aruco tags match between virtual and physical boards.

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -174,8 +174,8 @@ even on more inexpensive hardware, and as such uses a minimal amount of viewpoin
 Also, [make you are checking if your board is legacy, and if you can 
 allow default corner ordering](#check-if-you-have-a-legacy-charuco-board).
 
-If you are using a robot to collect your dataset, such as Spot, increase the settle
-time prior to taking an image (see ```--settle_time```)
+If you are using a robot to collect your dataset, such as Spot, you can
+also try increasing the settle time prior to taking an image (see ```--settle_time```)
 
 ## Using the Registered Information with Spot ROS 2
 If you have the [Spot ROS 2 Driver](https://github.com/bdaiinstitute/spot_ros2) installed,

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -11,14 +11,15 @@
 
 1. [***Overview***](#overview)
 2. [***Adapting Automatic Collection and Calibration to Your Scenario***](#adapting-automatic-data-collection-and-calibration-to-your-scenario)
-3. [***Calibrate Spot Manipulator Eye-In-Hand Cameras With the CLI Tool***](#calibrate-spot-manipulator-eye-in-hand-cameras-with-the-cli-tool)
+3. [***Check if you have a Legacy Charuco Board***](#check-if-you-have-a-legacy-charuco-board)
+4. [***Calibrate Spot Manipulator Eye-In-Hand Cameras With the CLI Tool***](#calibrate-spot-manipulator-eye-in-hand-cameras-with-the-cli-tool)
     - [Robot and Target Setup](#robot-and-target-setup)
     - [Example Usage](#example-usage-aka-hand-specific-live-incantations)
     - [Improving Calibration Quality](#improving-calibration-quality)
     - [Using the Registered Information with Spot ROS 2](#using-the-registered-information-with-spot-ros-2)
-4. [***Using the CLI Tool To Calibrate On an Existing Dataset***](#using-the-cli-tool-to-calibrate-on-an-existing-dataset)
-5. [***Understanding the Output Calibration Config File from the CLI***](#understanding-the-output-calibration-config-file-from-the-cli)
-6. [Recreate the Core Calibration CLI Tool Without Depending On Spot Wrapper](#recreate-the-core-calibration-cli-tool-without-depending-on-spot-wrapper)
+5. [***Using the CLI Tool To Calibrate On an Existing Dataset***](#using-the-cli-tool-to-calibrate-on-an-existing-dataset)
+6. [***Understanding the Output Calibration Config File from the CLI***](#understanding-the-output-calibration-config-file-from-the-cli)
+7. [Recreate the Core Calibration CLI Tool Without Depending On Spot Wrapper](#recreate-the-core-calibration-cli-tool-without-depending-on-spot-wrapper)
 
 # Overview
 This utility streamlines automatic
@@ -56,6 +57,23 @@ the new camera image in ```SpotInHandCalibration.capture_images``` in ```spot_in
 list of images obtained with the default cameras (assuming that the new camera
 is fixed relative to the existing cameras.).
 
+# Check if you have a Legacy Charuco Board
+Through using the CLI tool (```python3 calibrate_multistereo_cameras_with_charuco_cli.py -h```), you can check if you have a legacy board through visually comparing the generated drawn virtual board to your physical charuco board target. Some legacy boards have an aruco tag in the top
+left corner, whether as some non-legacy boards have a checker in the top left corner.
+Also, check to see that the aruco tags match between virtual and physical boards.
+It is important that the virtual board matches the physical board, otherwise this calibration
+will not work.
+
+```
+python3 calibrate_multistereo_cameras_with_charuco_cli.py --check_board_pattern --legacy_charuco_pattern t 
+```
+
+There should be an axis at the center of the board, where the Y axis (green)
+points upwards, the X axis (red) points to the right, and the figure should be labelled
+as Z-axis out of board. If it isn't then try without legacy (```--legacy_charuco_pattern f```).
+
+If you are using the default Spot Calibation board, and there is an aruco marker
+in the top left corner, then it legacy (so supply true argument to legacy.)
 
 # Calibrate Spot Manipulator Eye-In-Hand Cameras With the CLI tool
 
@@ -109,18 +127,20 @@ For all possible arguments to the Hand Specific CLI tool, run ```python3 calibra
 Many parameters are customizable.
 
 If you'd like to calibrate depth to rgb, with rgb at default resolution, saving photos to ```~/my_collection/calibrated.yaml```, 
-here is an example CLI command template, under the default tag (recommended for first time)
+here is an example CLI command template, under the default tag (recommended for first time).
+Note that the default Spot Board is a legacy pattern for OpenCV > 4.7, so ensure to pass
+the --legacy_charuco_pattern flag 
 ```
 python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_path ~/my_collection/ \
---save_data --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0)]" \
+--save_data --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0)]" --legacy_charuco_pattern True \
 --spot_rgb_photo_width=640 --spot_rgb_photo_height=480 --tag default
 ```
 If you'd like to load photos, and run the calibration with slightly different parameters, 
 while saving both the resuls and the parameters to same the config file as in the previous example.
 Here is an example CLI command template (from recorded images, no data collection)
 ```
-python3 calibrate_spot_hand_camera_cli.py --data_path ~/my_collection/ --from_data \
---result_path ~/my_collection/bottle_calibrated.yaml --photo_utilization_ratio 2 --stereo_pairs "[(1,0)]" \
+python3 calibrate_multistereo_cameras_with_charuco_cli.py --data_path ~/my_collection/ 
+--result_path ~/my_collection/bottle_calibrated.yaml --photo_utilization_ratio 2 --stereo_pairs "[(1,0)]" --legacy_charuco_pattern True \
 --spot_rgb_photo_width=640 --spot_rgb_photo_height=480 --tag less_photos_used_test_v1
 ```
 If you'd like to calibrate depth to rgb, at a greater resolution, while sampling
@@ -130,7 +150,7 @@ to demonstrate the stereo pairs argument, let's assume that you also want to fin
 demonstration purposes), while writing to the same config files as above.
 ```
 python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_path ~/my_collection/ \
---save_data --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (0,1)]" \
+--save_data --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (0,1)]" --legacy_charuco_pattern True\
 --spot_rgb_photo_width=1920 --spot_rgb_photo_height=1080 --x_axis_rot_viewpoint_range -10 10 1 \
 --dist_from_board_viewpoint_range .6 .9 .1
 ```
@@ -139,7 +159,10 @@ python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_
 If you find that the calibration quality isn't high enough, try a longer calibration
 with a wider variety of viewpoints (decrease the step size, increase the bounds). 
 The default calibration viewpoint parameters are meant to facilitate a quick  calibration
-even on more inexpensive hardware, and as such uses a minimal amount of viewpoints.
+even on more inexpensive hardware, and as such uses a minimal amount of viewpoints. 
+
+Also, [make you are checking if your board is legacy, and if you can 
+allow default corner ordering](#check-if-you-have-a-legacy-charuco-board)
 
 ## Using the Registered Information with Spot ROS 2
 If you have the [Spot ROS 2 Driver](https://github.com/bdaiinstitute/spot_ros2) installed,
@@ -174,6 +197,7 @@ If you'd like to register camera 1 to camera 0, and camera 2 to camera 0, you co
 ```
 python3 calibrate_multistereo_cameras_with_charuco_cli.py --data_path ~/existing_dataset/ \
 --result_path ~/existing_dataset/eye_in_hand_calib.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (2, 0)]" \
+--legacy_charuco_pattern=SUPPLY_CHECK_BOARD_FLAG_TO_SEE_IF_LEGACY_NEEDED \
 --tag default --unsafe_tag_save
 ```
 
@@ -236,7 +260,7 @@ If you like the core tools of this utility, and you'd like a more portable versi
 use independent of Spot that doesn't depend on Spot Wrapper, you could recreate
 the CLI tool with no dependency on Spot Wrapper with the following command:
 ```
-cat calibration_util.py <(tail -n +3 automatic_camera_calibration_robot.py) <(tail -n +23 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
+cat calibration_util.py <(tail -n +3 automatic_camera_calibration_robot.py) <(tail -n +26 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
 ```
 The core capability above depends primarily on NumPy, OpenCV and standard Python libraries.
 

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -72,7 +72,7 @@ def calibration_helper(
     if not args.allow_default_internal_corner_ordering:
         logger.warning("Turning off corner swap (needed for localization) for calibration solution...")
         logger.warning("Corner swap needed for initial localization, but breaks calibration.")
-        logger.warning("See ")
+        logger.warning("See https://github.com/opencv/opencv/issues/26126")
         detect_charuco_corners(
             create_ideal_charuco_image(charuco_board=charuco),
             charuco_board=charuco,

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -57,8 +57,11 @@ def main():
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = create_charuco_board(args.num_checkers_width, args.num_checkers_height, args.marker_dim, aruco_dict)
-
+    charuco = create_charuco_board(num_checkers_width=args.num_checkers_width, 
+                                    num_checkers_height=args.num_checkers_height, 
+                                    checker_dim=args.checker_dim,
+                                    marker_dim=args.marker_dim, 
+                                    aruco_dict=aruco_dict)
     logger.info(f"Loading images from {args.data_path}")
     images = load_images_from_path(args.data_path)
     calibration_helper(images=images, args=args, charuco=charuco, aruco_dict=aruco_dict)

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -9,10 +9,10 @@ import cv2
 import numpy as np
 
 from spot_wrapper.calibration.calibration_util import (
+    create_charuco_board,
     load_images_from_path,
     multistereo_calibration_charuco,
     save_calibration_parameters,
-    create_charuco_board
 )
 
 logging.basicConfig(
@@ -57,11 +57,8 @@ def main():
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = create_charuco_board(args.num_checkers_width,
-                                   args.num_checkers_height,
-                                   args.marker_dim,
-                                   aruco_dict)
-    
+    charuco = create_charuco_board(args.num_checkers_width, args.num_checkers_height, args.marker_dim, aruco_dict)
+
     logger.info(f"Loading images from {args.data_path}")
     images = load_images_from_path(args.data_path)
     calibration_helper(images=images, args=args, charuco=charuco, aruco_dict=aruco_dict)

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -47,17 +47,25 @@ def calibration_helper(
     logger.info(f"Finished script, obtained {calibration}")
     logger.info("Saving calibration param")
 
-    if args.result_path is not None:
-        save_calibration_parameters(
-            data=calibration,
-            output_path=args.result_path,
-            num_images=len(images[:: args.photo_utilization_ratio]),
-            tag=args.tag,
-            parser_args=args,
-            unsafe=args.unsafe_tag_save,
-        )
-    else:
-        logger.warning("Ran the calibration, but COULD NOT SAVE PARAMETERS: supply -rp")
+    # If result path is not provided, prompt the user for one
+    if args.result_path is None:
+        result_path = input("Please provide a path to save the calibration results (or type 'No' to skip): ")
+        
+        if result_path.lower() == "no":
+            logger.warning("Ran the calibration, but user opted not to save parameters.")
+            return
+        else:
+            args.result_path = result_path
+
+    # Save the calibration parameters if a valid result path is provided
+    save_calibration_parameters(
+        data=calibration,
+        output_path=args.result_path,
+        num_images=len(images[:: args.photo_utilization_ratio]),
+        tag=args.tag,
+        parser_args=args,
+        unsafe=args.unsafe_tag_save,
+    )
 
 
 def setup_calibration_param(parser):

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -50,7 +50,7 @@ def calibration_helper(
     # If result path is not provided, prompt the user for one
     if args.result_path is None:
         result_path = input("Please provide a path to save the calibration results (or type 'No' to skip): ")
-        
+
         if result_path.lower() == "no":
             logger.warning("Ran the calibration, but user opted not to save parameters.")
             return

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -12,11 +12,13 @@ from spot_wrapper.calibration.calibration_util import (
     load_images_from_path,
     multistereo_calibration_charuco,
     save_calibration_parameters,
+    create_charuco_board
 )
 
 logging.basicConfig(
     level=logging.INFO,
 )
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,13 +57,11 @@ def main():
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = cv2.aruco.CharucoBoard_create(
-        args.num_checkers_width,
-        args.num_checkers_height,
-        args.checker_dim,
-        args.marker_dim,
-        aruco_dict,
-    )
+    charuco = create_charuco_board(args.num_checkers_width,
+                                   args.num_checkers_height,
+                                   args.marker_dim,
+                                   aruco_dict)
+    
     logger.info(f"Loading images from {args.data_path}")
     images = load_images_from_path(args.data_path)
     calibration_helper(images=images, args=args, charuco=charuco, aruco_dict=aruco_dict)

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -57,11 +57,13 @@ def main():
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = create_charuco_board(num_checkers_width=args.num_checkers_width, 
-                                    num_checkers_height=args.num_checkers_height, 
-                                    checker_dim=args.checker_dim,
-                                    marker_dim=args.marker_dim, 
-                                    aruco_dict=aruco_dict)
+    charuco = create_charuco_board(
+        num_checkers_width=args.num_checkers_width,
+        num_checkers_height=args.num_checkers_height,
+        checker_dim=args.checker_dim,
+        marker_dim=args.marker_dim,
+        aruco_dict=aruco_dict,
+    )
     logger.info(f"Loading images from {args.data_path}")
     images = load_images_from_path(args.data_path)
     calibration_helper(images=images, args=args, charuco=charuco, aruco_dict=aruco_dict)

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -34,11 +34,13 @@ def spot_main() -> None:
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = create_charuco_board(num_checkers_width=args.num_checkers_width, 
-                                   num_checkers_height=args.num_checkers_height, 
-                                   checker_dim=args.checker_dim,
-                                   marker_dim=args.marker_dim, 
-                                   aruco_dict=aruco_dict)
+    charuco = create_charuco_board(
+        num_checkers_width=args.num_checkers_width,
+        num_checkers_height=args.num_checkers_height,
+        checker_dim=args.checker_dim,
+        marker_dim=args.marker_dim,
+        aruco_dict=aruco_dict,
+    )
 
     if not args.from_data:
         logger.warning("This script moves the robot around. !!! USE AT YOUR OWN RISK !!!")

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -12,9 +12,9 @@ from spot_wrapper.calibration.calibrate_multistereo_cameras_with_charuco_cli imp
     calibrator_cli,
 )
 from spot_wrapper.calibration.calibration_util import (
+    create_charuco_board,
     get_multiple_perspective_camera_calibration_dataset,
     load_images_from_path,
-    create_charuco_board
 )
 from spot_wrapper.calibration.spot_in_hand_camera_calibration import (
     SpotInHandCalibration,
@@ -34,11 +34,8 @@ def spot_main() -> None:
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = create_charuco_board(args.num_checkers_width,
-                                   args.num_checkers_height,
-                                   args.marker_dim,
-                                   aruco_dict)
-    
+    charuco = create_charuco_board(args.num_checkers_width, args.num_checkers_height, args.marker_dim, aruco_dict)
+
     if not args.from_data:
         logger.warning("This script moves the robot around. !!! USE AT YOUR OWN RISK !!!")
         logger.warning("HOLD Ctrl + C NOW TO CANCEL")

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -109,7 +109,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         nargs="+",
         type=float,
         dest="dist_from_board_viewpoint_range",
-        default=[0.6, 0.7, 0.2],
+        default=[0.5, 0.6, 0.1],
         help=(
             "What distances to conduct calibrations at relative to the board. (along the normal vector) "
             "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "
@@ -132,13 +132,14 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         action="store_false",
         help="Use radians for rotation ranges",
     )
-    for axis in ["x", "y", "z"]:
+    defaults = [[-10, 11, 10], [-10, 11, 10], [-10, 11, 10]]
+    for idx, axis in enumerate(["x", "y", "z"]):
         parser.add_argument(
             f"--{axis}_axis_rot_viewpoint_range",
             f"-{axis}arvr",
             nargs="+",
             type=float,
-            default=[-30, 31, 10],
+            default=defaults[idx],
             dest=f"{axis}_axis_rot_viewpoint_range",
             help=(
                 f"What range of viewpoints around {axis}-axis to sample relative to boards normal vector. "

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -88,7 +88,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         dest="ip",
         type=str,
         help="The IP address of the Robot to calibrate",
-        required=False,
+        required=True,
     )
     parser.add_argument(
         "--user",
@@ -97,7 +97,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         dest="username",
         type=str,
         help="Robot Username",
-        required=False,
+        required=True,
     )
     parser.add_argument(
         "--pass",
@@ -106,7 +106,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         dest="password",
         type=str,
         help="Robot Password",
-        required=False,
+        required=True,
     )
 
     parser.add_argument(

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -34,7 +34,11 @@ def spot_main() -> None:
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = create_charuco_board(args.num_checkers_width, args.num_checkers_height, args.marker_dim, aruco_dict)
+    charuco = create_charuco_board(num_checkers_width=args.num_checkers_width, 
+                                   num_checkers_height=args.num_checkers_height, 
+                                   checker_dim=args.checker_dim,
+                                   marker_dim=args.marker_dim, 
+                                   aruco_dict=aruco_dict)
 
     if not args.from_data:
         logger.warning("This script moves the robot around. !!! USE AT YOUR OWN RISK !!!")

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -109,7 +109,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         nargs="+",
         type=float,
         dest="dist_from_board_viewpoint_range",
-        default=[0.6, 0.7, 0.2],
+        default=[0.4, 0.5, 0.2],
         help=(
             "What distances to conduct calibrations at relative to the board. (along the normal vector) "
             "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -109,7 +109,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         nargs="+",
         type=float,
         dest="dist_from_board_viewpoint_range",
-        default=[0.4, 0.5, 0.2],
+        default=[0.6, 0.7, 0.2],
         help=(
             "What distances to conduct calibrations at relative to the board. (along the normal vector) "
             "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -70,7 +70,7 @@ def spot_main() -> None:
             x_axis_rots=np.arange(*args.x_axis_rot_viewpoint_range),
             y_axis_rots=np.arange(*args.y_axis_rot_viewpoint_range),
             z_axis_rots=np.arange(*args.z_axis_rot_viewpoint_range),
-            use_degrees=args.degrees,
+            use_degrees=args.use_degrees,
             settle_time=args.settle_time,
             data_path=args.data_path,
             save_data=args.save_data,

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -14,6 +14,7 @@ from spot_wrapper.calibration.calibrate_multistereo_cameras_with_charuco_cli imp
 from spot_wrapper.calibration.calibration_util import (
     get_multiple_perspective_camera_calibration_dataset,
     load_images_from_path,
+    create_charuco_board
 )
 from spot_wrapper.calibration.spot_in_hand_camera_calibration import (
     SpotInHandCalibration,
@@ -33,14 +34,11 @@ def spot_main() -> None:
         aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
     else:
         raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = cv2.aruco.CharucoBoard_create(
-        args.num_checkers_width,
-        args.num_checkers_height,
-        args.checker_dim,
-        args.marker_dim,
-        aruco_dict,
-    )
-
+    charuco = create_charuco_board(args.num_checkers_width,
+                                   args.num_checkers_height,
+                                   args.marker_dim,
+                                   aruco_dict)
+    
     if not args.from_data:
         logger.warning("This script moves the robot around. !!! USE AT YOUR OWN RISK !!!")
         logger.warning("HOLD Ctrl + C NOW TO CANCEL")

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -4,15 +4,14 @@ import argparse
 import logging
 from time import sleep
 
-import cv2
 import numpy as np
 
 from spot_wrapper.calibration.calibrate_multistereo_cameras_with_charuco_cli import (
     calibration_helper,
     calibrator_cli,
+    setup_calibration_param,
 )
 from spot_wrapper.calibration.calibration_util import (
-    create_charuco_board,
     get_multiple_perspective_camera_calibration_dataset,
     load_images_from_path,
 )
@@ -29,18 +28,7 @@ logger = logging.getLogger(__name__)
 
 def spot_main() -> None:
     parser = spot_cli(calibrator_cli())
-    args = parser.parse_args()
-    if hasattr(cv2.aruco, args.dict_size):
-        aruco_dict = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, args.dict_size))
-    else:
-        raise ValueError(f"Invalid ArUco dictionary: {args.dict_size}")
-    charuco = create_charuco_board(
-        num_checkers_width=args.num_checkers_width,
-        num_checkers_height=args.num_checkers_height,
-        checker_dim=args.checker_dim,
-        marker_dim=args.marker_dim,
-        aruco_dict=aruco_dict,
-    )
+    args, aruco_dict, charuco = setup_calibration_param(parser)
 
     if not args.from_data:
         logger.warning("This script moves the robot around. !!! USE AT YOUR OWN RISK !!!")

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -162,7 +162,7 @@ def spot_cli(parser=argparse.ArgumentParser) -> argparse.ArgumentParser:
         "-st",
         dest="settle_time",
         type=float,
-        default=0.5,
+        default=1.0,
         help="How long to wait after movement to take a picture; don't want motion blur",
     )
 

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -562,7 +562,6 @@ def calibrate_single_camera_charuco(
     for idx, img in enumerate(images):
         if img_size is None:
             img_size = img.shape[:2][::-1]
-        
 
         charuco_corners, charuco_ids = detect_charuco_corners(img, charuco_board, aruco_dict)
 

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -495,7 +495,7 @@ def detect_charuco_corners(
             and detect_charuco_corners.enforce_ids
             and hasattr(detect_charuco_corners, "corr_map")
         ):  # correlation map computed
-            # logger.warning("Using cached comp map..")
+            logger.warning("Using cached comp map..")
             correlation_map = detect_charuco_corners.corr_map  # grab the map
 
         reworked_charuco_ids = []

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -448,7 +448,7 @@ def detect_charuco_corners(
         # Newer OpenCV version with charuco_detector
         detector_params = cv2.aruco.CharucoParameters()
         detector_params.minMarkers = 0
-        detector_params.tryRefineMarkers = True
+        #detector_params.tryRefineMarkers = True
         charuco_detector = cv2.aruco.CharucoDetector(charuco_board, detector_params)
         charuco_detector.setBoard(charuco_board)
         charuco_corners, charuco_ids, _, _ = charuco_detector.detectBoard(gray)
@@ -697,6 +697,7 @@ def stereo_calibration_charuco(
 
         if len(obj_points_all) > 0:
             logger.info(f"Collected {len(obj_points_all)} shared point sets for stereo calibration.")
+            #logger.info(f"{np.array(obj_points_all).shape = } {np.array()}")
             _, _, _, _, _, R, T, _, _ = cv2.stereoCalibrate(
                 obj_points_all,
                 img_points_origin,
@@ -1158,15 +1159,11 @@ def charuco_pose_sanity_check(
         """Determine if the Z-axis points out of the Charuco board (towards the camera)."""
         return tvec[2] > 0  # If Z is positive, it points out of the board
 
-    def transform_pose_to_camera_frame(rmat, tvec):
-        """Transforms the pose to the camera frame by applying the inverse of the rotation."""
-        return rmat.T, -np.dot(rmat.T, tvec)
-
     def visualize_pose_with_axis(img, rmat, tvec, camera_matrix, dist_coeffs, axis_length=0.115):
         """Draws the 3D pose axes on the image and displays if the Z-axis is out or into the board."""
         axis = np.float32([[axis_length, 0, 0], [0, axis_length, 0], [0, 0, axis_length], [0, 0, 0]]).reshape(-1, 3)
 
-        rmat_camera, tvec_camera = transform_pose_to_camera_frame(rmat, tvec)
+        rmat_camera, tvec_camera = rmat, tvec 
         imgpts, _ = cv2.projectPoints(axis, rmat_camera, tvec_camera, camera_matrix, dist_coeffs)
 
         z_out_of_board = is_z_axis_out_of_board(tvec)

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -25,7 +25,60 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 SPOT_DEFAULT_ARUCO_DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
-SPOT_DEFAULT_CHARUCO = cv2.aruco.CharucoBoard_create(9, 4, 0.115, 0.09, SPOT_DEFAULT_ARUCO_DICT)
+
+def create_charuco_board(num_checkers_width: int, 
+                         num_checkers_height: int, 
+                         checker_dim: float, marker_dim: float, 
+                         aruco_dict: cv2.aruco_Dictionary) -> cv2.aruco_CharucoBoard:
+    """
+    Create a Charuco board using the provided parameters and Aruco dictionary.
+    Issues a deprecation warning if using the older 'CharucoBoard_create' method.
+
+    Args:
+        num_checkers_width (int): Number of checkers along the width of the board.
+        num_checkers_height (int): Number of checkers along the height of the board.
+        checker_dim (float): Size of the checker squares.
+        marker_dim (float): Size of the Aruco marker squares.
+        aruco_dict (cv2.aruco_Dictionary): The Aruco dictionary to use for marker generation.
+
+    Returns:
+        charuco (cv2.aruco_CharucoBoard): The generated Charuco board.
+    """
+
+    opencv_version = tuple(map(int, cv2.__version__.split('.')))
+
+    if opencv_version < (4, 7, 0):
+        logger.warning(
+            "You're using an older version of OpenCV that has charuco outside of core capability (in contrib)"
+            "Consider upgrading to OpenCV >= 4.7.0 for including charuco capability in core.",
+        )
+
+        # Create Charuco board using the older method
+        charuco = cv2.aruco.CharucoBoard_create(
+            num_checkers_width,
+            num_checkers_height,
+            checker_dim,
+            marker_dim,
+            aruco_dict,
+        )
+    else:
+        # Create Charuco board using the newer method
+        charuco = cv2.aruco_CharucoBoard(
+            (num_checkers_width, num_checkers_height),
+            checker_dim,
+            marker_dim,
+            aruco_dict,
+        )
+
+
+    return charuco
+
+SPOT_DEFAULT_CHARUCO = create_charuco_board(num_checkers_width=9,
+                                            num_checkers_height=4,
+                                            checker_dim=.115,
+                                            marker_dim=.09,
+                                            aruco_dict=SPOT_DEFAULT_ARUCO_DICT)
+
 
 
 def get_multiple_perspective_camera_calibration_dataset(

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -767,7 +767,6 @@ def est_camera_t_charuco_board_center(
 
             tvec = tvec + rmat.dot(center_trans)
             tvec_to_camera = -rmat.T @ tvec
-
             return np.array(rmat), np.array(tvec_to_camera).ravel()
         else:
             raise ValueError("Pose estimation failed. You likely primed the robot too close to the board.")

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -766,7 +766,6 @@ def est_camera_t_charuco_board_center(
             rmat, _ = cv2.Rodrigues(rvec)
 
             tvec = tvec + rmat.dot(center_trans)
-            # tvec_to_camera = -rmat.T @ tvec
             tvec_to_camera = tvec
             return np.array(rmat), np.array(tvec_to_camera).ravel()
         else:
@@ -777,69 +776,6 @@ def est_camera_t_charuco_board_center(
             "localization failed. Ensure the board is visible from the"
             " primed pose."
         )
-
-
-# def est_camera_t_charuco_board_center(
-#     img: np.ndarray,
-#     charuco_board: cv2.aruco_CharucoBoard,
-#     aruco_dict: cv2.aruco_Dictionary,
-#     camera_matrix: np.ndarray,
-#     dist_coeffs: np.ndarray,
-# ) -> Tuple[np.ndarray, np.ndarray]:
-#     """
-#     Localizes the 6D pose of the checkerboard center using Charuco corners.
-
-#     The board pose's translation should be at the center of the board, with the orientation
-#     in OpenCV format, where the +Z points out of the board with
-#     the other axis being parallel to the sides of the board.
-
-#     Args:
-#         img (np.ndarray): The input image containing the checkerboard.
-#         charuco_board (cv2.aruco_CharucoBoard): The Charuco board configuration.
-#         aruco_dict (cv2.aruco_Dictionary): The Aruco dictionary used to detect markers.
-#         camera_matrix (np.ndarray): The camera matrix from calibration.
-#         dist_coeffs (np.ndarray): The distortion coefficients from calibration.
-
-#     Returns:
-#         Optional[Tuple[np.ndarray, np.ndarray]]: The rotation vector and translation vector
-#         representing the 6D pose of the checkerboard center if found, else None.
-#     """
-#     charuco_corners, charuco_ids = detect_charuco_corners(img, charuco_board, aruco_dict)
-
-#     if charuco_corners is not None and charuco_ids is not None:
-#         # Estimate the pose of the Charuco board
-#         rvec = np.zeros((3, 1))
-#         tvec = np.zeros((3, 1))
-#         retval, rvec, tvec = cv2.aruco.estimatePoseCharucoBoard(
-#             charuco_corners,
-#             charuco_ids,
-#             charuco_board,
-#             camera_matrix,
-#             dist_coeffs,
-#             rvec,
-#             tvec,
-#         )
-#         if retval:
-#             # Compute the translations needed to transform to the center
-#             x_trans = (charuco_board.getSquareLength() * charuco_board.getChessboardSize()[0]) / 2.0
-#             y_trans = (charuco_board.getSquareLength() * charuco_board.getChessboardSize()[1]) / 2.0
-#             # Adjust tvec to be relative to the center
-#             center_trans = np.array([x_trans, y_trans, 0.0]).reshape((3, 1))
-#             rmat, _ = cv2.Rodrigues(rvec)
-#             tvec = tvec + rmat.dot(center_trans)
-
-#             return np.array(rmat), np.array(tvec).ravel()
-#         else:
-#             raise ValueError(
-#                 "Corners were found, but failed to localize. You likely primed the robot too close to the board"
-#             )
-#     else:
-#         raise ValueError(
-#             "Couldn't detect any Charuco Boards in the image, "
-#             "localization failed. Ensure the board is visible from the"
-#             " primed pose."
-#         )
-
 
 def convert_camera_t_viewpoint_to_origin_t_planning_frame(
     origin_t_planning_frame: np.ndarray = np.eye(4),

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -442,6 +442,8 @@ def detect_charuco_corners(
                 corners, ids, gray, charuco_board, minMarkers=0
             )
             return charuco_corners, charuco_ids
+        else:
+            return None, None
     else:
         # Newer OpenCV version with charuco_detector
         detector_params = cv2.aruco.CharucoParameters()
@@ -450,6 +452,9 @@ def detect_charuco_corners(
         charuco_detector = cv2.aruco.CharucoDetector(charuco_board, detector_params)
         charuco_detector.setBoard(charuco_board)
         charuco_corners, charuco_ids, _, _ = charuco_detector.detectBoard(gray)
+
+        if charuco_ids is None:
+            return None, None
 
         enforce_ids = enforce_ascending_ids_from_bottom_left_corner
         if enforce_ids is not None and hasattr(detect_charuco_corners, "enforce_ids"):
@@ -557,6 +562,7 @@ def calibrate_single_camera_charuco(
     for idx, img in enumerate(images):
         if img_size is None:
             img_size = img.shape[:2][::-1]
+        
 
         charuco_corners, charuco_ids = detect_charuco_corners(img, charuco_board, aruco_dict)
 
@@ -776,6 +782,7 @@ def est_camera_t_charuco_board_center(
             "localization failed. Ensure the board is visible from the"
             " primed pose."
         )
+
 
 def convert_camera_t_viewpoint_to_origin_t_planning_frame(
     origin_t_planning_frame: np.ndarray = np.eye(4),

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -26,10 +26,14 @@ logger = logging.getLogger(__name__)
 
 SPOT_DEFAULT_ARUCO_DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
 
-def create_charuco_board(num_checkers_width: int, 
-                         num_checkers_height: int, 
-                         checker_dim: float, marker_dim: float, 
-                         aruco_dict: cv2.aruco_Dictionary) -> cv2.aruco_CharucoBoard:
+
+def create_charuco_board(
+    num_checkers_width: int,
+    num_checkers_height: int,
+    checker_dim: float,
+    marker_dim: float,
+    aruco_dict: cv2.aruco_Dictionary,
+) -> cv2.aruco_CharucoBoard:
     """
     Create a Charuco board using the provided parameters and Aruco dictionary.
     Issues a deprecation warning if using the older 'CharucoBoard_create' method.
@@ -45,12 +49,14 @@ def create_charuco_board(num_checkers_width: int,
         charuco (cv2.aruco_CharucoBoard): The generated Charuco board.
     """
 
-    opencv_version = tuple(map(int, cv2.__version__.split('.')))
+    opencv_version = tuple(map(int, cv2.__version__.split(".")))
 
     if opencv_version < (4, 7, 0):
         logger.warning(
-            "You're using an older version of OpenCV that has charuco outside of core capability (in contrib)"
-            "Consider upgrading to OpenCV >= 4.7.0 for including charuco capability in core.",
+            (
+                "You're using an older version of OpenCV that has charuco outside of core capability (in contrib)"
+                "Consider upgrading to OpenCV >= 4.7.0 for including charuco capability in core."
+            ),
         )
 
         # Create Charuco board using the older method
@@ -70,15 +76,12 @@ def create_charuco_board(num_checkers_width: int,
             aruco_dict,
         )
 
-
     return charuco
 
-SPOT_DEFAULT_CHARUCO = create_charuco_board(num_checkers_width=9,
-                                            num_checkers_height=4,
-                                            checker_dim=.115,
-                                            marker_dim=.09,
-                                            aruco_dict=SPOT_DEFAULT_ARUCO_DICT)
 
+SPOT_DEFAULT_CHARUCO = create_charuco_board(
+    num_checkers_width=9, num_checkers_height=4, checker_dim=0.115, marker_dim=0.09, aruco_dict=SPOT_DEFAULT_ARUCO_DICT
+)
 
 
 def get_multiple_perspective_camera_calibration_dataset(

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -766,7 +766,8 @@ def est_camera_t_charuco_board_center(
             rmat, _ = cv2.Rodrigues(rvec)
 
             tvec = tvec + rmat.dot(center_trans)
-            tvec_to_camera = -rmat.T @ tvec
+            #tvec_to_camera = -rmat.T @ tvec
+            tvec_to_camera = tvec
             return np.array(rmat), np.array(tvec_to_camera).ravel()
         else:
             raise ValueError("Pose estimation failed. You likely primed the robot too close to the board.")
@@ -775,8 +776,67 @@ def est_camera_t_charuco_board_center(
             "Couldn't detect any Charuco boards in the image, "
             "localization failed. Ensure the board is visible from the"
             " primed pose."
-        )
+         )
+# def est_camera_t_charuco_board_center(
+#     img: np.ndarray,
+#     charuco_board: cv2.aruco_CharucoBoard,
+#     aruco_dict: cv2.aruco_Dictionary,
+#     camera_matrix: np.ndarray,
+#     dist_coeffs: np.ndarray,
+# ) -> Tuple[np.ndarray, np.ndarray]:
+#     """
+#     Localizes the 6D pose of the checkerboard center using Charuco corners.
 
+#     The board pose's translation should be at the center of the board, with the orientation
+#     in OpenCV format, where the +Z points out of the board with
+#     the other axis being parallel to the sides of the board.
+
+#     Args:
+#         img (np.ndarray): The input image containing the checkerboard.
+#         charuco_board (cv2.aruco_CharucoBoard): The Charuco board configuration.
+#         aruco_dict (cv2.aruco_Dictionary): The Aruco dictionary used to detect markers.
+#         camera_matrix (np.ndarray): The camera matrix from calibration.
+#         dist_coeffs (np.ndarray): The distortion coefficients from calibration.
+
+#     Returns:
+#         Optional[Tuple[np.ndarray, np.ndarray]]: The rotation vector and translation vector
+#         representing the 6D pose of the checkerboard center if found, else None.
+#     """
+#     charuco_corners, charuco_ids = detect_charuco_corners(img, charuco_board, aruco_dict)
+
+#     if charuco_corners is not None and charuco_ids is not None:
+#         # Estimate the pose of the Charuco board
+#         rvec = np.zeros((3, 1))
+#         tvec = np.zeros((3, 1))
+#         retval, rvec, tvec = cv2.aruco.estimatePoseCharucoBoard(
+#             charuco_corners,
+#             charuco_ids,
+#             charuco_board,
+#             camera_matrix,
+#             dist_coeffs,
+#             rvec,
+#             tvec,
+#         )
+#         if retval:
+#             # Compute the translations needed to transform to the center
+#             x_trans = (charuco_board.getSquareLength() * charuco_board.getChessboardSize()[0]) / 2.0
+#             y_trans = (charuco_board.getSquareLength() * charuco_board.getChessboardSize()[1]) / 2.0
+#             # Adjust tvec to be relative to the center
+#             center_trans = np.array([x_trans, y_trans, 0.0]).reshape((3, 1))
+#             rmat, _ = cv2.Rodrigues(rvec)
+#             tvec = tvec + rmat.dot(center_trans)
+
+#             return np.array(rmat), np.array(tvec).ravel()
+#         else:
+#             raise ValueError(
+#                 "Corners were found, but failed to localize. You likely primed the robot too close to the board"
+#             )
+#     else:
+#         raise ValueError(
+#             "Couldn't detect any Charuco Boards in the image, "
+#             "localization failed. Ensure the board is visible from the"
+#             " primed pose."
+#         )
 
 def convert_camera_t_viewpoint_to_origin_t_planning_frame(
     origin_t_planning_frame: np.ndarray = np.eye(4),

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -448,7 +448,7 @@ def detect_charuco_corners(
         # Newer OpenCV version with charuco_detector
         detector_params = cv2.aruco.CharucoParameters()
         detector_params.minMarkers = 0
-        detector_params.tryRefineMarkers = True  # Makes calibration NaNs
+        detector_params.tryRefineMarkers = True
         charuco_detector = cv2.aruco.CharucoDetector(charuco_board, detector_params)
         charuco_detector.setBoard(charuco_board)
         charuco_corners, charuco_ids, _, _ = charuco_detector.detectBoard(gray)

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -766,7 +766,7 @@ def est_camera_t_charuco_board_center(
             rmat, _ = cv2.Rodrigues(rvec)
 
             tvec = tvec + rmat.dot(center_trans)
-            #tvec_to_camera = -rmat.T @ tvec
+            # tvec_to_camera = -rmat.T @ tvec
             tvec_to_camera = tvec
             return np.array(rmat), np.array(tvec_to_camera).ravel()
         else:
@@ -776,7 +776,9 @@ def est_camera_t_charuco_board_center(
             "Couldn't detect any Charuco boards in the image, "
             "localization failed. Ensure the board is visible from the"
             " primed pose."
-         )
+        )
+
+
 # def est_camera_t_charuco_board_center(
 #     img: np.ndarray,
 #     charuco_board: cv2.aruco_CharucoBoard,
@@ -837,6 +839,7 @@ def est_camera_t_charuco_board_center(
 #             "localization failed. Ensure the board is visible from the"
 #             " primed pose."
 #         )
+
 
 def convert_camera_t_viewpoint_to_origin_t_planning_frame(
     origin_t_planning_frame: np.ndarray = np.eye(4),

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -495,7 +495,7 @@ def detect_charuco_corners(
             and detect_charuco_corners.enforce_ids
             and hasattr(detect_charuco_corners, "corr_map")
         ):  # correlation map computed
-            logger.warning("Using cached comp map..")
+            logger.warning("Using cached correlation map to order IDs")
             correlation_map = detect_charuco_corners.corr_map  # grab the map
 
         reworked_charuco_ids = []

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -139,8 +139,8 @@ class SpotInHandCalibration(AutomaticCameraCalibrationRobot):
                 self.estimated_camera_matrix,
                 self.estimated_camera_distort_coeffs,
             )
-        except AttributeError:
-            raise ValueError("Must call _set_localization_param prior to localizing")
+        except AttributeError as e:
+            raise ValueError(f"Must call _set_localization_param prior to localizing: {e}")
 
     def move_cameras_to_see_calibration_target(self) -> np.ndarray:
         def adjust_standing_height(height: float) -> None:

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -41,6 +41,8 @@ from spot_wrapper.calibration.automatic_camera_calibration_robot import (
 from spot_wrapper.calibration.calibration_util import (
     convert_camera_t_viewpoint_to_origin_t_planning_frame,
     est_camera_t_charuco_board_center,
+    SPOT_DEFAULT_ARUCO_DICT,
+    SPOT_DEFAULT_CHARUCO
 )
 
 logging.basicConfig(
@@ -48,9 +50,6 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
-SPOT_DEFAULT_ARUCO_DICT = cv2.aruco.getPredefinedDictionary(cv2.aruco.DICT_4X4_50)
-SPOT_DEFAULT_CHARUCO = cv2.aruco.CharucoBoard_create(9, 4, 0.115, 0.09, SPOT_DEFAULT_ARUCO_DICT)
-
 
 class SpotInHandCalibration(AutomaticCameraCalibrationRobot):
     def __init__(self, ip: str, username: str, password: str):

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -41,8 +41,6 @@ from spot_wrapper.calibration.automatic_camera_calibration_robot import (
 from spot_wrapper.calibration.calibration_util import (
     convert_camera_t_viewpoint_to_origin_t_planning_frame,
     est_camera_t_charuco_board_center,
-    SPOT_DEFAULT_ARUCO_DICT,
-    SPOT_DEFAULT_CHARUCO
 )
 
 logging.basicConfig(
@@ -50,6 +48,7 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
 
 class SpotInHandCalibration(AutomaticCameraCalibrationRobot):
     def __init__(self, ip: str, username: str, password: str):


### PR DESCRIPTION
In OpenCV 4.7.0, charuco was moved from the contrib part of opencv to the core part of opencv (https://github.com/opencv/opencv/pull/22986/files#diff-09508dfcb283f5b8f2e58538584a58ce28d369f8c7e23705f004f7d15e6f40e9). Previously, the code assumed an OpenCV version prior to 4.7.0.

This adds an explicit check for the opencv version prior to prior to many charuco operations, so that the correct charuco method can be called for opencv>=4.7 despite the breaking change in 4.7

More information about OpenCV changes:
https://github.com/opencv/opencv/issues/26126

This also adds an explicit dependency on opencv. Previously, this dependency was likely implicitly included if you use the spot_ros2 package (due to dependency on things like cv bridge), but this not cover the use case of using spot_wrapper completely independently of ROS2.

It is better to check OpenCV version, and adjust behavior accordingly, then just depending on opencv-contrib-python, as
depending on contrib can break existing versions of OpenCV on your system when the requirements.txt is installed

Testing:

Tested on physical robot. For code changes with OpenCV, verified the results in prior to 4.7 and after:
https://github.com/opencv/opencv/issues/26126