### PR TITLE
Add lease to graph_nav

### DIFF
--- a/spot_wrapper/spot_graph_nav.py
+++ b/spot_wrapper/spot_graph_nav.py
@@ -293,6 +293,9 @@ class SpotGraphNav:
             self._logger.error("Failed to find waypoint id.")
             return
 
+        self._lease = self._get_lease()
+        self._lease_keepalive = LeaseKeepAlive(self._lease_client)
+        
         robot_state = self._robot_state_client.get_robot_state()
         current_odom_tform_body = get_odom_tform_body(robot_state.kinematic_state.transforms_snapshot).to_proto()
         # Create an initial localization to the specified waypoint as the identity.

--- a/spot_wrapper/spot_graph_nav.py
+++ b/spot_wrapper/spot_graph_nav.py
@@ -295,7 +295,7 @@ class SpotGraphNav:
 
         self._lease = self._get_lease()
         self._lease_keepalive = LeaseKeepAlive(self._lease_client)
-        
+
         robot_state = self._robot_state_client.get_robot_state()
         current_odom_tform_body = get_odom_tform_body(robot_state.kinematic_state.transforms_snapshot).to_proto()
         # Create an initial localization to the specified waypoint as the identity.


### PR DESCRIPTION
https://github.com/bdaiinstitute/spot_ros2/issues/486

Hello!

thank you for creating and maintaining this repo. It has been extremely helpful.
I did some work with the GraphNav ROS2 services and action server.

While I  was able to get it working, i encountered some issues, and wanted to share them.
I very well could have been using the ROS2 interfaces for SPOT incorrectly, but this usage pattern was built off reading the SPOT V4.0.3 documentation and samples, and looking at the examples, source code and documentation in this REPO.

To get SPOT working using GraphNav, I did the following:

1) ros2 service call /graph_nav_clear_graph spot_msgs/srv/GraphNavClearGraph
2) ros2 service call /graph_nav_upload_graph spot_msgs/srv/GraphNavUploadGraph "{upload_filepath: ./map.walk'}"
3)  ros2 service call /graph_nav_set_localization spot_msgs/srv/GraphNavSetLocalization  "{method: 'waypoint', waypoint_id: 'canny-mite-VQ.uUPtpNIimADm2yVAsWA=='}"

These work without any issue, with the 3rd step being the waypoint where our base station is.
we did all these from teh command line.

the fourth step , which calls the action server navigate_to had issues.

We found we had to make 3 changes to use this ROS2 action server:

1) in spot_wrapper/spot_Wrapper/spot_graph_nav.py, we had to add the request for a lease in set_initial_localization_waypoint (new lines 296-298)

        self._lease = self._get_lease()
        self._lease_keepalive = LeaseKeepAlive(self._lease_client)

2) in spot_driver/spot_driver/spot_ros2.py (lines 2823 - 2826) we had to change

           upload_path=goal_handle.request.upload_path,
            navigate_to=goal_handle.request.navigate_to,
            initial_localization_fiducial=goal_handle.request.initial_localization_fiducial,
            initial_localization_waypoint=goal_handle.request.initial_localization_waypoint,

to 
          waypoint_id=goal_handle.request.waypoint_id,

3) in spot_msgs/action/NavigateTO.action we needed to change the definition from

    string upload_path # Absolute path to map_directory, which is downloaded from tablet controller
    string navigate_to # Waypoint id string for where to go
    bool initial_localization_fiducial   # Tells the initializer whether to use fiducials
    string initial_localization_waypoint # Waypoint id to trigger localization 
    ---
    bool success   # indicate successful run of triggered service
    string message # informational, e.g. for error messages
    ---
    string waypoint_id

to

    string waypoint_id # waypoint ID to navigate to
    ---
    bool success   # indicate successful run of triggered service
    string message # informational, e.g. for error messages
    ---
    string waypoint_id 


It looks as though the action server interface changed in implementation, but the action server interface was not updated.

did I call the API wrong, or did we find valid bugs?

thanks
Dan

