### PR TITLE
[N/A] bump requirements.txt for 4.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
     strategy:
       matrix:
         config:
-        - { python: "3.8" }
-        - { python: "3.9" }
         - { python: "3.10" }
     name: Run pre-commit
     runs-on: ubuntu-latest
@@ -46,8 +44,6 @@ jobs:
     strategy:
       matrix:
         config:
-        - { python: "3.8" }
-        - { python: "3.9" }
         - { python: "3.10" }
     name: Test spot_wrapper package
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 This Python package is a wrapper around the [Boston Dynamics Spot SDK](https://dev.bostondynamics.com), intended as a united point of entry to the SDK for use with the [spot_ros](https://github.com/heuristicus/spot_ros) and [spot_ros2](https://github.com/bdaiinstitute/spot_ros2) packages.
 
+This package currently corresponds to `spot-sdk` release 4.1.0. As support for Python 3.8 and 3.9 was dropped in this release, the minimum supported version of Python this package supports is 3.10. 
+
 # Installation
 
 To install this package clone it and run

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 aiortc==1.5.0
-bosdyn-api==4.0.2
-bosdyn-choreography-client==4.0.2
-bosdyn-client==4.0.2
-bosdyn-core==4.0.2
-bosdyn-mission==4.0.2
+bosdyn-api==4.1.0
+bosdyn-choreography-client==4.1.0
+bosdyn-client==4.1.0
+bosdyn-core==4.1.0
+bosdyn-mission==4.1.0
 grpcio==1.59.3
 image==1.5.33
 inflection==0.5.1


### PR DESCRIPTION
Counterpart to https://github.com/bdaiinstitute/spot_ros2/pull/495 that updates this repo for spot-sdk release 4.1.0.

Additionally, stops running CI tests for Python 3.8 and 3.9 as this isn't supported by this release of the spot-sdk and updates the README to reflect this.