### PR TITLE
Disable GraphNav streaming uploads

### DIFF
--- a/spot_wrapper/spot_graph_nav.py
+++ b/spot_wrapper/spot_graph_nav.py
@@ -30,6 +30,8 @@ class SpotGraphNav:
         self._robot = robot
         self._logger = logger
         self._graph_nav_client = graph_nav_client
+        # TODO: re-enable streaming graph uploads when fixed upstream
+        self._graph_nav_client._use_streaming_graph_upload = False
         self._map_processing_client = map_processing_client
         self._robot_state_client = robot_state_client
         self._lease_client = lease_client


### PR DESCRIPTION
Spot SDK 4.1.0 brought in the feature but the implementation has issues. This patch disables it (for now).