### PR TITLE
[SW-1712] Pin ubuntu version in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         config:
         - { python: "3.10" }
     name: Run pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
         config:
         - { python: "3.10" }
     name: Test spot_wrapper package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Change Overview

This is simply a find/replace of `ubuntu-latest` -> `ubuntu-22.04`.  Because `ubuntu-latest` will become 24.04 soon.  We should pin to 22.04 which matches our development environment.

## Testing Done

None. This PR is the test.  (Assuming this repo has CI)

