### PR TITLE
fix: pinned np to 1.25.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pytest-cov==4.1.0
 pytest-xdist==3.5.0
 pyyaml>=6.0
 setuptools==59.6.0
-numpy==1.25.2
+numpy==1.21.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pytest-cov==4.1.0
 pytest-xdist==3.5.0
 pyyaml>=6.0
 setuptools==59.6.0
+numpy==1.25.2


### PR DESCRIPTION
pip dependency resolver installs numpy >2 with `[install_spot_ros2.sh](https://github.com/bdaiinstitute/spot_ros2/blob/main/install_spot_ros2.sh)`

Conflicts with ROS2 and several packages such as `cv_bridge`

Pinned numpy to 1.25.2 in `requirements.txt`

Fixes:

https://github.com/bdaiinstitute/spot_ros2/issues/492

https://github.com/bdaiinstitute/spot_ros2/issues/555