### PR TITLE
Fix false trajectory success when blocked by obstacle

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -270,8 +270,10 @@ class AsyncIdle(AsyncPeriodicQuery):
                 )
 
                 if status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_STOPPED:
-                    self.stopped = True
                     # Robot is stopped
+                    self.stopped = True
+                    self._spot_wrapper._trajectory_status_unknown = False
+                    self._spot_wrapper.last_trajectory_command = None
                     if (
                         final_goal_status
                         == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_ACHIEVABLE
@@ -279,11 +281,8 @@ class AsyncIdle(AsyncPeriodicQuery):
                         self._spot_wrapper.trajectory_complete = True
                         self._spot_wrapper.at_goal = True
                         # Clear the command once at the goal
-                        self._spot_wrapper.last_trajectory_command = None
-                        self._spot_wrapper._trajectory_status_unknown = False
                     elif final_goal_status == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_BLOCKED:
                         self._spot_wrapper.trajectory_complete = True
-                        self._spot_wrapper.last_trajectory_command = None
                     elif (
                         final_goal_status
                         == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_IN_PROGRESS

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -273,16 +273,17 @@ class AsyncIdle(AsyncPeriodicQuery):
                     # Robot is stopped
                     self.stopped = True
                     self._spot_wrapper._trajectory_status_unknown = False
-                    self._spot_wrapper.last_trajectory_command = None
                     if (
                         final_goal_status
                         == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_ACHIEVABLE
                     ):
                         self._spot_wrapper.trajectory_complete = True
                         self._spot_wrapper.at_goal = True
+                        self._spot_wrapper.last_trajectory_command = None
                         # Clear the command once at the goal
                     elif final_goal_status == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_BLOCKED:
                         self._spot_wrapper.trajectory_complete = True
+                        self._spot_wrapper.last_trajectory_command = None
                     elif (
                         final_goal_status
                         == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_IN_PROGRESS

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -272,7 +272,10 @@ class AsyncIdle(AsyncPeriodicQuery):
                 if status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_STOPPED:
                     self.stopped = True
                     # Robot is stopped
-                    if final_goal_status == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_ACHIEVABLE:
+                    if (
+                        final_goal_status
+                        == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_ACHIEVABLE
+                    ):
                         self._spot_wrapper.trajectory_complete = True
                         self._spot_wrapper.at_goal = True
                         # Clear the command once at the goal
@@ -281,12 +284,15 @@ class AsyncIdle(AsyncPeriodicQuery):
                     elif final_goal_status == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_BLOCKED:
                         self._spot_wrapper.trajectory_complete = True
                         self._spot_wrapper.last_trajectory_command = None
-                    elif final_goal_status == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_IN_PROGRESS:
+                    elif (
+                        final_goal_status
+                        == basic_command_pb2.SE2TrajectoryCommand.Feedback.FINAL_GOAL_STATUS_IN_PROGRESS
+                    ):
                         self._logger.info(
-                            "Robot stopped but trajectory still in progress. Perhaps something is in the way")
+                            "Robot stopped but trajectory still in progress. Perhaps something is in the way"
+                        )
                     else:
-                        self._logger.error(
-                            "Robot stopped but final goal status is unknown.")
+                        self._logger.error("Robot stopped but final goal status is unknown.")
                         self._spot_wrapper.last_trajectory_command = None
                 elif status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_STOPPING:
                     is_moving = True


### PR DESCRIPTION
As per [jira ticket](https://theaiinstitute.atlassian.net/browse/SW-2016), we previously denoted “reaching the goal” as being when basic_command_pb2.SE2TrajectoryCommand.Feedback.Status has value STATUS_GOING_TO_GOAL, or STATUS_NEAR_GOAL, both of which, according to spot-sdk,  were “possibly confusing in situations where the robot cannot achieve the requested trajectory and are now deprecated” ([link](https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference.html#se2trajectorycommand-feedback-status)).

I have updated the logic in spot_wrapper to no longer use those deprecated flags. This is necessary for spot_driver in spot_ros2 to properly report when the robot is blocked by an obstacle.