### PR TITLE
Integrate the frame_prefix argument and make robot_name optional (related to https://github.com/bdaiinstitute/spot_ros2/pull/506).

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -372,8 +372,9 @@ class SpotWrapper:
         password: str,
         hostname: str,
         port: int,
-        robot_name: str,
         logger: logging.Logger,
+        robot_name: typing.Optional[str] = None,
+        frame_prefix: typing.Optional[str] = None,
         start_estop: bool = True,
         estop_timeout: float = 9.0,
         rates: typing.Optional[typing.Dict[str, float]] = None,
@@ -392,6 +393,7 @@ class SpotWrapper:
             password: Password for authentication with the robot
             hostname: ip address or hostname of the robot
             robot_name: Optional name of the robot
+            frame_prefix: Optional prefix to be used for published message frames. If not provided, robot_name will be used to construct the prefix instead.
             start_estop: If true, the wrapper will be an estop endpoint
             estop_timeout: Timeout for the estop in seconds. The SDK will check in with the wrapper at a rate of
                            estop_timeout/3 and if there is no communication the robot will execute a gentle stop.
@@ -412,7 +414,6 @@ class SpotWrapper:
         self._password = password
         self._hostname = hostname
         self._payload_credentials_file = payload_credentials_file
-        self._robot_name = robot_name
         self._rates = rates or {}
         self._callbacks = callbacks or {}
         self._use_take_lease = use_take_lease
@@ -420,9 +421,8 @@ class SpotWrapper:
         self.decorate_functions()
         self._continually_try_stand = continually_try_stand
         self._rgb_cameras = rgb_cameras
-        self._frame_prefix = ""
-        if robot_name is not None:
-            self._frame_prefix = robot_name + "/"
+        self._robot_name = robot_name if robot_name is not None else ""
+        self._frame_prefix = frame_prefix if frame_prefix is not None else (robot_name + "/" if robot_name is not None else "")
         self._logger = logger
         self._estop_timeout = estop_timeout
         self._start_estop = start_estop

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -393,7 +393,8 @@ class SpotWrapper:
             password: Password for authentication with the robot
             hostname: ip address or hostname of the robot
             robot_name: Optional name of the robot
-            frame_prefix: Optional prefix to be used for published message frames. If not provided, robot_name will be used to construct the prefix instead.
+            frame_prefix: Optional prefix to be used for published message frames. If not provided, robot_name will
+                          be used to construct the prefix instead.
             start_estop: If true, the wrapper will be an estop endpoint
             estop_timeout: Timeout for the estop in seconds. The SDK will check in with the wrapper at a rate of
                            estop_timeout/3 and if there is no communication the robot will execute a gentle stop.
@@ -422,7 +423,9 @@ class SpotWrapper:
         self._continually_try_stand = continually_try_stand
         self._rgb_cameras = rgb_cameras
         self._robot_name = robot_name if robot_name is not None else ""
-        self._frame_prefix = frame_prefix if frame_prefix is not None else (robot_name + "/" if robot_name is not None else "")
+        self._frame_prefix = (
+            frame_prefix if frame_prefix is not None else (robot_name + "/" if robot_name is not None else "")
+        )
         self._logger = logger
         self._estop_timeout = estop_timeout
         self._start_estop = start_estop

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -372,8 +372,8 @@ class SpotWrapper:
         password: str,
         hostname: str,
         port: int,
+        robot_name: str,
         logger: logging.Logger,
-        robot_name: typing.Optional[str] = None,
         frame_prefix: typing.Optional[str] = None,
         start_estop: bool = True,
         estop_timeout: float = 9.0,
@@ -415,6 +415,7 @@ class SpotWrapper:
         self._password = password
         self._hostname = hostname
         self._payload_credentials_file = payload_credentials_file
+        self._robot_name = robot_name
         self._rates = rates or {}
         self._callbacks = callbacks or {}
         self._use_take_lease = use_take_lease
@@ -422,10 +423,7 @@ class SpotWrapper:
         self.decorate_functions()
         self._continually_try_stand = continually_try_stand
         self._rgb_cameras = rgb_cameras
-        self._robot_name = robot_name if robot_name is not None else ""
-        self._frame_prefix = (
-            frame_prefix if frame_prefix is not None else (robot_name + "/" if robot_name is not None else "")
-        )
+        self._frame_prefix = frame_prefix if frame_prefix is not None else (robot_name + "/" if robot_name else "")
         self._logger = logger
         self._estop_timeout = estop_timeout
         self._start_estop = start_estop


### PR DESCRIPTION
This PR is related to the changes proposed in https://github.com/bdaiinstitute/spot_ros2/pull/506.
* The new explicit `frame_prefix` parameter is exposed to the wrapper.
* The `robot_name` parameter is now actually optional.