### PR TITLE
sw-2047 fixed estop bug

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -997,6 +997,10 @@ class SpotWrapper:
             on the ground first
         """
         try:
+            if self._estop_keepalive is None:
+                self._logger.warning("Software e-stop keepalive does not exist; creating one now and asserting e-stop.")
+                self.resetEStop()
+
             if severe:
                 self._estop_keepalive.stop()
             else:


### PR DESCRIPTION
Calling robot's "estop/gentle" or "estop/hard" service would through an "attribute not found" error.

This was fixed by first checking whether this attribute (spot_wrapper's self._estop_keepalive) was non-None, and resetting (and thus instantiating) the estop if not, while throwing a warning to the user that the software estop was not previously initialized. I figured initializing the estop was preferable over simply telling the user the estop did not exist and thus could not be called, for safety reasons. But open to suggestions!

This was tested on Opal.