### PR TITLE
[N/A] Flag to disable obstacle avoidance in trajectory_cmd

### DIFF
--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1352,7 +1352,7 @@ class SpotWrapper:
             true, the robot must complete its final positioning before it will be considered to have successfully
             reached the goal.
             mobility_params: Mobility parameters to send along with this command
-            disable_vision_body_obstacle_avoidance: flag to easier set mobility_params.obstacle_params flag above
+            disable_vision_body_obstacle_avoidance: flag to easily set mobility_params.obstacle_params flag above
 
         Returns:
             (bool, str) tuple indicating whether the command was successfully sent, and a message
@@ -1360,9 +1360,11 @@ class SpotWrapper:
         if mobility_params is None:
             mobility_params = self._mobility_params
         if disable_vision_body_obstacle_avoidance:
-            self._logger.error("Caution: attempting to send mobility trajectory without obstacle avoidance")
-            mobility_params.obstacle_params.disable_vision_body_obstacle_avoidance = disable_vision_body_obstacle_avoidance
-        
+            self._logger.warning("Caution: attempting to send mobility trajectory without obstacle avoidance")
+            mobility_params.obstacle_params.disable_vision_body_obstacle_avoidance = (
+                disable_vision_body_obstacle_avoidance
+            )
+
         self._trajectory_status_unknown = False
         self.trajectory_complete = False
         self.stopped = False

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -1338,6 +1338,7 @@ class SpotWrapper:
         frame_name: str = "odom",
         precise_position: bool = False,
         mobility_params: spot_command_pb2.MobilityParams = None,
+        disable_vision_body_obstacle_avoidance: bool = False,
     ) -> typing.Tuple[bool, str]:
         """Send a trajectory motion command to the robot.
 
@@ -1351,12 +1352,17 @@ class SpotWrapper:
             true, the robot must complete its final positioning before it will be considered to have successfully
             reached the goal.
             mobility_params: Mobility parameters to send along with this command
+            disable_vision_body_obstacle_avoidance: flag to easier set mobility_params.obstacle_params flag above
 
         Returns:
             (bool, str) tuple indicating whether the command was successfully sent, and a message
         """
         if mobility_params is None:
             mobility_params = self._mobility_params
+        if disable_vision_body_obstacle_avoidance:
+            self._logger.error("Caution: attempting to send mobility trajectory without obstacle avoidance")
+            mobility_params.obstacle_params.disable_vision_body_obstacle_avoidance = disable_vision_body_obstacle_avoidance
+        
         self._trajectory_status_unknown = False
         self.trajectory_complete = False
         self.stopped = False


### PR DESCRIPTION
Adds a flag to disable obstacle avoidance when executing a trajectory command.
Despite `mobility_params` being an argument to `trajectory_cmd` in order set this param higher up in the pipeline, we would need to import `spot_command_pb2.MobilityParams` higher up, which is a can of worms I would rather not do when it can be solved with a simple boolean here. Open to discussion though if anyone feels strongly.