### PR TITLE
[SW-2186] Upgrade to spot sdk 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This Python package is a wrapper around the [Boston Dynamics Spot SDK](https://dev.bostondynamics.com), intended as a united point of entry to the SDK for use with the [spot_ros](https://github.com/heuristicus/spot_ros) and [spot_ros2](https://github.com/bdaiinstitute/spot_ros2) packages.
 
-This package currently corresponds to `spot-sdk` release 4.1.1. The minimum supported version of Python this package supports is 3.10.
+This package currently corresponds to `spot-sdk` release 5.0.0. The minimum supported version of Python this package supports is 3.10.
 
 # Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 aiortc==1.5.0
-bosdyn-api==4.1.1
-bosdyn-choreography-client==4.1.1
-bosdyn-client==4.1.1
-bosdyn-core==4.1.1
-bosdyn-mission==4.1.1
+bosdyn-api==5.0.0
+bosdyn-choreography-client==5.0.0
+bosdyn-client==5.0.0
+bosdyn-core==5.0.0
+bosdyn-mission==5.0.0
 grpcio==1.59.3
 image==1.5.33
 inflection==0.5.1


### PR DESCRIPTION
Bumps Python Spot packages from 4.1.1 to 5.0.0

Tests:
* CI 
* Upstream testing in https://github.com/bdaiinstitute/spot_ros2/pull/665