### PR TITLE
implement spot leash resources for missing status/leases

### DIFF
--- a/spot_wrapper/spot_leash.py
+++ b/spot_wrapper/spot_leash.py
@@ -132,6 +132,10 @@ class SpotLeash(SpotLeashProtocol):
         return self._lease
 
     @property
+    def resources(self) -> list[lease_pb2.LeaseResource]:
+        return list(getattr(self._lease_task, "proto", []) or [])
+
+    @property
     def async_tasks(self) -> List[AsyncPeriodicQuery]:
         return [self._lease_task]
 


### PR DESCRIPTION
What changed
- Added resources property to SpotLeash returning the latest LeaseResource list from AsyncLease.

Why
- status/leases is not published after the spot leash redesign (worked in 4.0.1) as resources is only defined in SpotLeashProtocol but not implemented in SpotLeash. Implementing it restores the existing publication path in direct leasing mode without changing behavior elsewhere.

How it was tested
- Launched the node with leasing_mode=direct and lease_rate>0.
- Verified that the ROS2 topic status/leases is published (received non-empty LeaseArray).