### PR TITLE
[N/A] Fix the timeout overflow fix

### DIFF
--- a/spot_wrapper/testing/grpc.py
+++ b/spot_wrapper/testing/grpc.py
@@ -680,7 +680,10 @@ class ProxiedUnaryRpcHandler(ProxiedRpcHandler):
 
     def __call__(self, request: typing.Any, context: grpc.ServicerContext) -> typing.Any:
         future = self._server.submit(request)
-        return future.result(timeout=min(context.time_remaining(), threading.TIMEOUT_MAX))
+        time_remaining = context.time_remaining()
+        if time_remaining is not None:
+            time_remaining = min(time_remaining, threading.TIMEOUT_MAX)
+        return future.result(timeout=time_remaining)
 
 
 class ProxiedStreamRpcHandler(ProxiedRpcHandler):
@@ -688,4 +691,7 @@ class ProxiedStreamRpcHandler(ProxiedRpcHandler):
 
     def __call__(self, request: typing.Any, context: grpc.ServicerContext) -> typing.Iterator:
         future = self._server.submit(request)
-        yield from future.result(timeout=min(context.time_remaining(), threading.TIMEOUT_MAX))
+        time_remaining = context.time_remaining()
+        if time_remaining is not None:
+            time_remaining = min(time_remaining, threading.TIMEOUT_MAX)
+        yield from future.result(timeout=time_remaining)


### PR DESCRIPTION
Follow-up to #177. Neither tests nor `mypy` caught this, but gRPC documents that `context.time_remaining()` may be `None`. This patch handles that case.