### PR TITLE
[SW-2808] Send camera calibrations to spot

### DIFF
--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -33,8 +33,12 @@ camera calibration to **solve for the intrinsic and extrinsic parameters for two
 cameras mounted in a fixed pose relative to each other on a robot**
 based off of moving the robot to view a Charuco target from different poses. If you already
 have an existing dataset of synchronized stereo (or multi-stereo) photos of a Charuco target from different viewpoints,
-you can use the CLI tool to compute the intrinsic/extrinsic parameters. Additionally,
-the CLI tool's saving capability allows to store multiple unique calibration runs in one configuration file
+you can use the CLI tool to compute the intrinsic/extrinsic parameters. Additionally, if you have saved the poses the images are taken at (as homogenous 4x4 transforms from the "world" frame [most likely the robot base] to the robot planning frame [most likely the
+robot end-effector]), you can also calibrate
+the camera to robot extrinsic (eye-to-hand registration). If you don't have a dataset,
+you can use this tool both to generate the dataset and calibrate the cameras.
+
+The CLI tool's saving capability allows to store multiple unique calibration runs in one configuration file
 with calibration metadata, to document related runs with different setups or parameters.
 
 This was developed to calibrate the two cameras at the

--- a/spot_wrapper/calibration/README.md
+++ b/spot_wrapper/calibration/README.md
@@ -1,13 +1,15 @@
 # Automatic Robotic Stereo Camera Calibration Utility with Charuco Target (a.k.a Multi-Stereo Madness)
 
 ## Find where your cameras are relative to each other, and relative to your robot
-##  Find how your cameras project 3D points into pixels
+
+## Find how your cameras project 3D points into pixels
 
 ### Recommended Setup
 
 ![spot eye in hand cal](spot_eye_in_hand_setup.jpg)
 
 ### Reference Image
+
 ![side by side comparison](registration_qualitative_example.jpg)
 
 # Table of Contents
@@ -27,20 +29,16 @@
 # Overview
 
 This utility streamlines automatic
-camera calibration to **solve for the intrinsic and extrinsic parameters for two or more 
+camera calibration to **solve for the intrinsic and extrinsic parameters for two or more
 cameras mounted in a fixed pose relative to each other on a robot**
-based off of moving the robot to view a Charuco target from different poses. If you already 
-have an existing dataset of synchronized stereo (or multi-stereo) photos of a Charuco target from different viewpoints, 
-you can use the CLI tool to compute the intrinsic/extrinsic parameters. Additionally, if you have saved the poses the images are taken at (as homogenous 4x4 transforms from the "world" frame [most likely the robot base] to the robot planning frame [most likely the 
-robot end-effector]), you can also calibrate
-the camera to robot extrinsic (eye-to-hand registration). If you don't have a dataset,
-you can use this tool both to generate the dataset and calibrate the cameras.
-
-The CLI tool's saving capability allows to store multiple unique calibration runs in one configuration file
+based off of moving the robot to view a Charuco target from different poses. If you already
+have an existing dataset of synchronized stereo (or multi-stereo) photos of a Charuco target from different viewpoints,
+you can use the CLI tool to compute the intrinsic/extrinsic parameters. Additionally,
+the CLI tool's saving capability allows to store multiple unique calibration runs in one configuration file
 with calibration metadata, to document related runs with different setups or parameters.
 
-This was developed to calibrate the two cameras at the 
-end of Spot's optional manipulator payload, while being **as general as possible 
+This was developed to calibrate the two cameras at the
+end of Spot's optional manipulator payload, while being **as general as possible
 to be easily adapted to new robots and camera configurations. The core calibration utilities depend only on NumPy and OpenCV.**
 
 This utility works by sampling viewpoints relative to the Charuco calibration board,
@@ -55,7 +53,7 @@ do most of the heavy lifting.
 
 Assuming that you have a charuco board you'd like to automatically calibrate your cameras/robot with:
 
-**To calibrate a new robot with new cameras using the utility**, implement the abstract class ```AutomaticCameraCalibrationRobot``` from ```automatic_camera_calibration_robot.py``` 
+**To calibrate a new robot with new cameras using the utility**, implement the abstract class ```AutomaticCameraCalibrationRobot``` from ```automatic_camera_calibration_robot.py```
 (Only five methods, that are likely analogous to what's needed for automatic calibration even if this utility isn't used.
 in Spot's case , excluding comments, it's under ~250 lines of code, see ```spot_in_hand_camera_calibration.py```),
 and pass the implemented class as an argument to ```get_multiple_perspective_camera_calibration_dataset``` from ```calibration_util.py``` (see ```calibrate_spot_hand_camera_cli.py``` for an example).
@@ -89,50 +87,51 @@ in the top left corner, then it legacy (so supply true argument to legacy.)
 
 # Calibrate Spot Manipulator Eye-In-Hand Cameras With the CLI tool
 
-There is an [existing method to calibrate the gripper cameras with the Spot Api](https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference#bosdyn-api-spot-GripperCameraCalibrationCommandRequest). However, you don't have 
+There is an [existing method to calibrate the gripper cameras with the Spot Api](https://dev.bostondynamics.com/protos/bosdyn/api/proto_reference#bosdyn-api-spot-GripperCameraCalibrationCommandRequest). However, you don't have
 as much control and extensibility in the existing method as with this custom procedure.
 
-In Spot's hand, there is an RGB camera, as well as a ToF camera, which ```calibrate_spot_hand_camera_cli.py``` 
+In Spot's hand, there is an RGB camera, as well as a ToF camera, which ```calibrate_spot_hand_camera_cli.py```
 automatically co-registers using the calibration utility via the default calibration board included
 with most Spots. You can also use a different board if you'd like, just set the right CLI parameters
 (see example usage below)
 
 ## Robot and Target Setup
+
 Have Spot sit on the ground with the arm stowed such that nothing is within a meter of the robot.
 Spot should NOT be on its charging dock.
 
-No program should have robot control authority. Make sure Spot is sitting 
+No program should have robot control authority. Make sure Spot is sitting
 with the arm stowed before releasing robot authority.
-If you are using the ROS 2 Driver, disconnect from Spot. If you are using the tablet to control Spot, 
+If you are using the ROS 2 Driver, disconnect from Spot. If you are using the tablet to control Spot,
 select power icon (top) -> Advanced -> Release control.
 
 Place the Spot default calibration board on the ground leaning against something in front of Spot, so
 that the calibration board's pattern is facing Spot front (where the stowed arm points).
 The up arrow should point in the direction of the sky. The board should be tilted away from
 Spot at a 45 degree angle, so that the bottom of the board is closer Spot than the top of the board. The ground beneath
-the board should be at about a 45 degree angle from the board. The board's bottom should be about a meter away 
+the board should be at about a 45 degree angle from the board. The board's bottom should be about a meter away
 from the front of Spot while sitting. Nothing should be within a meter of the robot.
 
 **See the first reference image at the top of this README to see good board placement relative to Spot.**
 
-When calibrating, Spot will stand up, ready its arm, lower its base slightly, and 
+When calibrating, Spot will stand up, ready its arm, lower its base slightly, and
 lower its arm slightly. As soon as this happens, if Spot
-can see a Charuco board it will start to move the arm around for the calibration. 
+can see a Charuco board it will start to move the arm around for the calibration.
 
 If the calibration board isn't placed at the right location, or there is more
 than one board visible to the robot, this may lead to potentially unsafe behavior, so be ready to
-E-Stop the robot at any moment. If the robot starts exhibiting unexpected behavior, stopping the program, 
+E-Stop the robot at any moment. If the robot starts exhibiting unexpected behavior, stopping the program,
 turning off the computer running the calibration, and hijacking control from the tablet can help stop robot movement.
 
-It is possible to calibrate at further distances 
+It is possible to calibrate at further distances
 (see ```--dist_from_board_viewpoint_range``` arg), but the sampling of the viewpoint
-distance from the board must be feasible to reach with where the base of the 
-robot is started relative to the board. The previously recommended Spot and Target setup is what worked well 
+distance from the board must be feasible to reach with where the base of the
+robot is started relative to the board. The previously recommended Spot and Target setup is what worked well
 in testing for the default distance viewpoint range.
 
 After the calibration is finished, Spot stows its arm and sits back down. At this point,
 it is safe to take control of Spot from the tablet or ROS 2 , even if the calibration script is still
-running. Just don't stop the script or it will stop calculating the parameters :) 
+running. Just don't stop the script or it will stop calculating the parameters :)
 
 If Spot is shaking while moving the arm around, it is likely that
 your viewpoint range is too close or too far (most often, adjusting
@@ -141,31 +140,37 @@ also try to drive the Spot to a better location to start the calibration
 that fits the distance from viewpoint range better.
 
 ## Example Usage (a.k.a Hand Specific Live Incantations)
+
 For all possible arguments to the Hand Specific CLI tool, run ```python3 calibrate_spot_hand_camera_cli.py -h```.
 Many parameters are customizable.
 
-If you'd like to calibrate depth to rgb, with rgb at default resolution, saving photos to ```~/my_collection/calibrated.yaml```, 
+If you'd like to calibrate depth to rgb, with rgb at default resolution, saving photos to ```~/my_collection/calibrated.yaml```,
 here is an example CLI command template, under the default tag (recommended for first time).
 Note that the default Spot Board is a legacy pattern for OpenCV > 4.7, so ensure to pass
-the --legacy_charuco_pattern flag 
+the --legacy_charuco_pattern flag
+
 ```
 python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_path ~/my_collection/ \
 --save_data --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0)]" --legacy_charuco_pattern True \
 --spot_rgb_photo_width=640 --spot_rgb_photo_height=480 --tag default
 ```
-If you'd like to load photos, and run the calibration with slightly different parameters, 
+
+If you'd like to load photos, and run the calibration with slightly different parameters,
 while saving both the resuls and the parameters to same the config file as in the previous example.
 Here is an example CLI command template (from recorded images, no data collection)
+
 ```
 python3 calibrate_multistereo_cameras_with_charuco_cli.py --data_path ~/my_collection/ 
 --result_path ~/my_collection/bottle_calibrated.yaml --photo_utilization_ratio 2 --stereo_pairs "[(1,0)]" --legacy_charuco_pattern True \
 --spot_rgb_photo_width=640 --spot_rgb_photo_height=480 --tag less_photos_used_test_v1
 ```
+
 If you'd like to calibrate depth to rgb, at a greater resolution, while sampling
 viewpoints at finer X-rotation steps relative to the board, and slightly further from the board
 with finer steps, here is an example CLI command template. Also,
-to demonstrate the stereo pairs argument, let's assume that you also want to find rgb to depth (redundant for 
+to demonstrate the stereo pairs argument, let's assume that you also want to find rgb to depth (redundant for
 demonstration purposes), while writing to the same config files as above.
+
 ```
 python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_path ~/my_collection/ \
 --save_data --result_path ~/my_collection/calibrated.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (0,1)]" --legacy_charuco_pattern True\
@@ -174,31 +179,36 @@ python3 calibrate_spot_hand_camera_cli.py --ip <IP> -u user -pw <SECRET> --data_
 ```
 
 ## Improving Calibration Quality
+
 If you find that the calibration quality isn't high enough, try a longer calibration
-with a wider variety of viewpoints (decrease the step size, increase the bounds). 
+with a wider variety of viewpoints (decrease the step size, increase the bounds).
 The default calibration viewpoint parameters are meant to facilitate a quick calibration
-even on more inexpensive hardware, and as such uses a minimal amount of viewpoints. 
+even on more inexpensive hardware, and as such uses a minimal amount of viewpoints.
 
 However, in calibration, less is more. It is better to collect fewer high quality
 viewpoints then many low quality ones. Play with the viewpoint sampling parameters
 to find what takes the most diverse high quality photos of the board.
 
-Also, [make you are checking if your board is legacy, and if you can 
+Also, [make you are checking if your board is legacy, and if you can
 allow default corner ordering](#check-if-you-have-a-legacy-charuco-board).
 
 If you are using a robot to collect your dataset, such as Spot, you can
 also try increasing the settle time prior to taking an image (see ```--settle_time```)
 
 ## Using the Registered Information with Spot ROS 2
+
 If you have the [Spot ROS 2 Driver](https://github.com/bdaiinstitute/spot_ros2) installed,
 you can leverage the output of the automatic calibration to publish a depth image registered
 to the RGB image frame. For more info, see the ```Optional Automatic Eye-in-Hand Stereo Calibration Routine for Manipulator (Arm) Payload```
 section in the [spot_ros2 main README](https://github.com/bdaiinstitute/spot_ros2?tab=readme-ov-file#optional-automatic-eye-in-hand-stereo-calibration-routine-for-manipulator-arm-payload)
+
 # Using the CLI Tool To Calibrate On an Existing Dataset
-To use the CLI Tool, please ensure that you have one parent folder, 
-where each camera has a folder under the parent (Numbered from 0 to N). Synchronized photos 
+
+To use the CLI Tool, please ensure that you have one parent folder,
+where each camera has a folder under the parent (Numbered from 0 to N). Synchronized photos
 for each camera should appear in their respective directories, where matching photos have ids, ascending
 upwards, starting from 0. The file structure should appear something like the following:
+
 ```
 existing_dataset/
 ├── 0/
@@ -221,11 +231,11 @@ existing_dataset/
 
 Optionally, you can also include pose information, to find the camera to robot extrinsic.
 
-
 To see all possible arguments for calibration, please run  ```python3 calibrate_multistereo_cameras_with_charuco_cli.py -h```.
     Many parameters such as board proportions and Agmruco dictionary are customizable.
 
 If you'd like to register camera 1 to camera 0, and camera 2 to camera 0, you could do the following:
+
 ```
 python3 calibrate_multistereo_cameras_with_charuco_cli.py --data_path ~/existing_dataset/ \
 --result_path ~/existing_dataset/eye_in_hand_calib.yaml --photo_utilization_ratio 1 --stereo_pairs "[(1,0), (2, 0)]" \
@@ -236,7 +246,7 @@ python3 calibrate_multistereo_cameras_with_charuco_cli.py --data_path ~/existing
 # Understanding the Output Calibration Config File from the CLI
 
 A calibration produced with ```multistereo_calibration_charuco``` from ```calibration_util```
-can be saved as a ```.yaml```file with ```save_calibration_parameters``` from ```calibration_util```. 
+can be saved as a ```.yaml```file with ```save_calibration_parameters``` from ```calibration_util```.
 Here is a demonstration output calibration config file for example purposes:
 
 ```
@@ -272,13 +282,13 @@ default:
 ```
 
 Each calibration run
-that creates or modifies a config file is tagged with a unique name, to allow for tracking of several experiments, 
+that creates or modifies a config file is tagged with a unique name, to allow for tracking of several experiments,
 which is the main title (in the above case, ```default```).
 Under the main title, there are the fields relevant to the calibration.
 Under ```intrinsic```, the intrinsic (camera matrix, distortion coefficents, and image height/width)
 for each camera are recorded as a flattened representation
-under the camera's index number as it appears in the list of images 
-returned by ```capture_images```. For example, if ```capture_images``` produces a list that is 
+under the camera's index number as it appears in the list of images
+returned by ```capture_images```. For example, if ```capture_images``` produces a list that is
 ```[image_by_primary_camera, image_by_reference_camera]```, then the intrinsic for the ```primary_camera```
 would be stored under ```0```, and the intrinsic for ```reference_camera``` would be stored under ```1```.
 
@@ -286,22 +296,27 @@ Under ```extrinsic```, the first sublevel, again a camera index, corresponds to 
 is the origin for the ```extrinsic``` transform between two cameras as the first
 field in a requested stereo pair. The second sublevel corresponds to the index of which camera
 the ```extrinsic``` maps to from the origin camera. See the comments in the example config file
-above for more information. 
-Additionally, arguments from an argparser can also be dumped into the yaml, which will be saved 
+above for more information.
+Additionally, arguments from an argparser can also be dumped into the yaml, which will be saved
 under ```run_param``` (excluding args that are: ```password``` or ```username```)
 
 # Recreate the Core Calibration CLI Tool Without Depending On Spot Wrapper
-If you like the core tools of this utility, and you'd like a more portable version (```standalone_cli.py```) for 
+
+If you like the core tools of this utility, and you'd like a more portable version (```standalone_cli.py```) for
 use independent of Spot that doesn't depend on Spot Wrapper, you could recreate
 the CLI tool with no dependency on Spot Wrapper with the following command:
+
 ```
 cat calibration_util.py <(tail -n +3 automatic_camera_calibration_robot.py) <(tail -n +26 calibrate_multistereo_cameras_with_charuco_cli.py) > standalone_cli.py
 ```
+
 The core capability above depends primarily on NumPy, OpenCV and standard Python libraries.
 
 # Contributors
+
 Gary Lvov
 
-# Special Thanks To...
-Michael Pickett, Katie Hughes, Tiffany Cappellari, Andrew Messing, 
+# Special Thanks To
+
+Michael Pickett, Katie Hughes, Tiffany Cappellari, Andrew Messing,
 Emmanuel Panov, Eric Rosen, Brian Okorn, Joseph St Germain and Ken Baker.

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -173,6 +173,7 @@ def calibrate_robot_cli(parser: argparse.ArgumentParser = None) -> argparse.Argu
 
     return parser
 
+
 def spot_cli(parser: argparse.ArgumentParser = None) -> argparse.ArgumentParser:
     if parser is None:
         parser = calibrate_robot_cli()

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -173,6 +173,56 @@ def calibrate_robot_cli(parser: argparse.ArgumentParser = None) -> argparse.Argu
 
     return parser
 
+def spot_cli(parser: argparse.ArgumentParser = None) -> argparse.ArgumentParser:
+    if parser is None:
+        parser = calibrate_robot_cli()
+
+    parser.add_argument(
+        "--ip",
+        "-i",
+        "-ip",
+        dest="ip",
+        type=str,
+        help="The IP address of the Robot to calibrate",
+        required=True,
+    )
+    parser.add_argument(
+        "--user",
+        "-u",
+        "--username",
+        dest="username",
+        type=str,
+        help="Robot Username",
+        required=True,
+    )
+    parser.add_argument(
+        "--pass",
+        "-pw",
+        "--password",
+        dest="password",
+        type=str,
+        help="Robot Password",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--spot_rgb_photo_width",
+        "-dpw",
+        type=int,
+        default=640,
+        dest="spot_rgb_photo_width",
+        help="What resolution use for Spot's RGB Hand Camera (width). Currently, only 640 and 1920 are supported",
+    )
+
+    parser.add_argument(
+        "--spot_rgb_photo_height",
+        "-dph",
+        type=int,
+        default=480,
+        help="What resolution use for Spot's RGB Hand Camera (width). Currently, only 480 and 1080 are supported",
+    )
+    return parser
+
 
 def spot_cli(parser: argparse.ArgumentParser = None) -> argparse.ArgumentParser:
     if parser is None:

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -206,7 +206,7 @@ def multistereo_calibration_charuco(
     aruco_dict: cv2.aruco_Dictionary = SPOT_DEFAULT_ARUCO_DICT,
     camera_matrices: Optional[Dict] = {},
     dist_coeffs: Optional[Dict] = {},
-    poses: Union[np.ndarray, None] = None
+    poses: Union[np.ndarray, None] = None,
 ) -> Dict:
     """
     Calibrates the intrinsic and extrinsic parameters for multiple stereo camera pairs
@@ -577,7 +577,7 @@ def calibrate_single_camera_charuco(
         if charuco_corners is not None and len(charuco_corners) >= 8:
             all_corners.append(charuco_corners)
             all_ids.append(charuco_ids)
-            #used_image_ids.append(idx)
+            # used_image_ids.append(idx)
         else:
             logger.warning(f"Not enough corners detected in image index {idx} {debug_str}; ignoring")
 
@@ -614,7 +614,7 @@ def stereo_calibration_charuco(
     dist_coeffs_origin: Optional[np.ndarray] = None,
     camera_matrix_reference: Optional[np.ndarray] = None,
     dist_coeffs_reference: Optional[np.ndarray] = None,
-    poses: Union[np.ndarray, None] = None
+    poses: Union[np.ndarray, None] = None,
 ) -> Dict:
     """
     Perform a stereo calibration from a set of synchronized stereo images of a charuco calibration
@@ -648,24 +648,22 @@ def stereo_calibration_charuco(
     """
     if camera_matrix_origin is None or dist_coeffs_origin is None:
         logger.info("Calibrating Origin Camera individually")
-        (camera_matrix_origin, dist_coeffs_origin, 
-         rmats_origin, tvecs_origin) = (
-            calibrate_single_camera_charuco(
+        (camera_matrix_origin, dist_coeffs_origin, rmats_origin, tvecs_origin) = calibrate_single_camera_charuco(
             images=origin_images,
             charuco_board=charuco_board,
             aruco_dict=aruco_dict,
             debug_str="for origin camera",
-        ))
+        )
     if camera_matrix_reference is None or dist_coeffs_origin is None:
         logger.info("Calibrating reference Camera individually ")
-        (camera_matrix_reference, dist_coeffs_reference, 
-         rmats_reference, tvecs_reference) = (
+        (camera_matrix_reference, dist_coeffs_reference, rmats_reference, tvecs_reference) = (
             calibrate_single_camera_charuco(
-            images=reference_images,
-            charuco_board=charuco_board,
-            aruco_dict=aruco_dict,
-            debug_str="for reference camera",
-        ))
+                images=reference_images,
+                charuco_board=charuco_board,
+                aruco_dict=aruco_dict,
+                debug_str="for reference camera",
+            )
+        )
 
     if camera_matrix_origin is None or camera_matrix_reference is None:
         raise ValueError("Could not calibrate one of the cameras as desired")
@@ -675,7 +673,7 @@ def stereo_calibration_charuco(
     all_ids_origin = []
     all_ids_reference = []
     img_size = None
-    
+
     no_poses = poses is None
     if no_poses:
         poses = [x for x in range(len(origin_images))]
@@ -698,7 +696,7 @@ def stereo_calibration_charuco(
         reference_charuco_corners, reference_charuco_ids = detect_charuco_corners(
             reference_img, charuco_board, aruco_dict
         )
-        
+
         if not no_poses:
             filtered_poses.append(pose)
         if origin_charuco_corners is not None and reference_charuco_corners is not None:

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -253,7 +253,7 @@ def multistereo_calibration_charuco(
             to their distortion coefficients.
             If coefficients are not provided for a camera, they will be computed during calibration.
             Defaults to an empty dictionary.
-        poses (Optional[np.ndarray]): Either a list of 4x4 homogenous transforms from which
+        poses (Union[np.ndarray, None]): Either a list of 4x4 homogenous transforms from which
             pictures where taken, or None if unknown. Needs to be supplied for robot to camera cal.
             (planning frame to base frame), or None
 
@@ -635,7 +635,7 @@ def stereo_calibration_charuco(
             matrix to assign to camera 1. If none, is computed. . Defaults to None.
         dist_coeffs_reference (Optional[np.ndarray], optional): What distortion coefficients
             to assign to camera 1. If None, is computed. Defaults to None.
-        poses (Optional[np.ndarray]): Either a list of 4x4 homogenous transforms from which
+        poses (Union[np.ndarray, None]): Either a list of 4x4 homogenous transforms from which
             pictures where taken, or None if unknown. Needs to be supplied for robot to camera cal.
             (planning frame to base frame), or None
     Raises:

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -19,7 +19,6 @@ from bosdyn.client.frame_helpers import (
     HAND_FRAME_NAME,
     get_a_tform_b,
 )
-from bosdyn.client.math_helpers import SE3Pose
 from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.image import ImageClient, build_image_request
 from bosdyn.client.lease import (
@@ -116,8 +115,9 @@ class SpotInHandCalibration(AutomaticCameraCalibrationRobot):
 
     def write_calibration_to_robot(self, cal=None):
         from bosdyn.api import gripper_camera_param_pb2
-        from bosdyn.api.geometry_pb2 import SE3Pose
-        from bosdyn.api.image_pb2 import PinholeModel
+        from bosdyn.api.image_pb2 import ImageSource
+        from bosdyn.client.math_helpers import SE3Pose
+
         ## The following works and is tested to return blank parameters on unset robot
         ############################################################################
         # get_req = gripper_camera_param_pb2.GripperCameraGetParamRequest()
@@ -130,7 +130,7 @@ class SpotInHandCalibration(AutomaticCameraCalibrationRobot):
 
         def convert_pinhole_intrinsic_to_proto(intrinsic_matrix):
             """Converts a 3x3 intrinsic matrix to a PinholeModel protobuf."""
-            pinhole_model = PinholeModel()
+            pinhole_model = ImageSource.PinholeModel()
             pinhole_model.focal_length_x = intrinsic_matrix[0, 0]
             pinhole_model.focal_length_y = intrinsic_matrix[1, 1]
             pinhole_model.principal_point_x = intrinsic_matrix[0, 2]

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -19,6 +19,7 @@ from bosdyn.client.frame_helpers import (
     HAND_FRAME_NAME,
     get_a_tform_b,
 )
+from bosdyn.client.math_helpers import SE3Pose
 from bosdyn.client.gripper_camera_param import GripperCameraParamClient
 from bosdyn.client.image import ImageClient, build_image_request
 from bosdyn.client.lease import (
@@ -108,6 +109,64 @@ class SpotInHandCalibration(AutomaticCameraCalibrationRobot):
         ]
         # Create a GripperCameraParamsClient
         self.gripper_camera_client = self.robot.ensure_client(GripperCameraParamClient.default_service_name)
+        # Katie and Gary cooked up right here !!!**** GripperCameraCalibration
+        self.write_calibration_to_robot()
+        raise ValueError("Did not mean to go this far")
+
+
+    def write_calibration_to_robot(self, cal = {}):
+        def convert_pinhole_intrinsic_to_proto(intrinsic_matrix):
+            """Converts a 3x3 intrinsic matrix to a PinholeModel protobuf."""
+            pinhole_model = PinholeModel()
+            pinhole_model.intrinsics.focal_length.x = intrinsic_matrix[0, 0]
+            pinhole_model.intrinsics.focal_length.y = intrinsic_matrix[1, 1]
+            pinhole_model.intrinsics.principal_point.x = intrinsic_matrix[0, 2]
+            pinhole_model.intrinsics.principal_point.y = intrinsic_matrix[1, 2]
+            return pinhole_model
+
+        if cal is None:
+            # Ripped from calib file
+            cal["depth_intrinsic"] = np.array([215.78570285824208, 0.0, 113.50899498114939, 0.0, 215.81041358956026,
+        91.52930962720102, 0.0, 0.0, 1.0]).reshape((3,3))
+            cal["rgb_intrinsic"] = np.array([[541.9417121434435, 0.0, 319.8759813692453, 0.0, 541.9183052872654,
+        235.87456783983524, 0.0, 0.0, 1.0]]).reshape((3,3))
+            cal["depth_to_rgb"] = np.array([
+                [0.0008540850814552694, -0.9999762875319601, 0.006833367579213797, 0.02068056344450553],
+                [0.999950571032565, 0.0009217136573264173, 0.009899794724194794, 0.014867920369954562],
+                [-0.009905858383852087, 0.006824574545926849, 0.9999276469584919, -0.011403325992053714],
+                [0, 0, 0, 1]
+            ])
+            cal["depth_to_planning_frame"] = np.array([
+                [0.13925927199025206, 0.03472611310021725, -0.9896468825968665, 0.012525123175595418],
+                [-0.05828697579746701, 0.9979396646727721, 0.02681518460091079, 0.01978439523093831],
+                [0.9885390652964254, 0.05394926080815518, 0.14099643130633896, 0.037143569257920686],
+                [0, 0, 0, 1]
+            ])
+            cal["rgb_to_planning_frame"] = np.linalg.inv(cal["depth_to_rgb"]) @ cal["depth_to_planning_frame"]
+
+            cal["depth_to_planning_frame"] = SE3Pose.from_matrix(cal["depth_to_planning_frame"]).to_proto()
+            cal["rgb_to_planning_frame"] = SE3Pose.from_matrix(cal["rgb_to_planning_frame"]).to_proto()
+
+        from bosdyn.api import gripper_camera_param_pb2
+        from bosdyn.api.image_pb2.ImageSource import PinholeModel
+        ## The following works and is tested to return blank parameters on unset robot
+        ############################################################################
+        # get_req = gripper_camera_param_pb2.GripperCameraGetParamRequest()
+        # cal = self.gripper_camera_client.get_camera_calib(get_req)
+        # print(f"Pre-Set Cal (get cam param req): \n {cal}")
+        # get_req = gripper_camera_param_pb2.GetGripperCameraCalibrationRequest()
+        # cal = self.gripper_camera_client.get_camera_calib(get_req)
+        # print(f"Pre-Set Cal (get calib param req): \n{cal}")
+        #############################################################################
+        set_req = gripper_camera_param_pb2.GripperCameraCalibrationRequest(
+            gripper_cam_cal=gripper_camera_param_pb2.GripperCameraCalibrationProto(
+                depth=gripper_camera_param_pb2.GripperDepthCameraCalibrationParams(),
+                rgb=gripper_camera_param_pb2.GripperColorCameraCalibrationParams()))
+        
+        results = self.gripper_camera_client.set_camera_calib(set_req)
+        print(results)
+
+
 
     def capture_images(
         self,

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -43,7 +43,7 @@ from spot_wrapper.calibration.calibration_util import (
     convert_camera_t_viewpoint_to_origin_t_planning_frame,
     est_camera_t_charuco_board_center,
 )
-from time import sleep
+
 logging.basicConfig(
     level=logging.INFO,
 )

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -43,7 +43,7 @@ from spot_wrapper.calibration.calibration_util import (
     convert_camera_t_viewpoint_to_origin_t_planning_frame,
     est_camera_t_charuco_board_center,
 )
-
+from time import sleep
 logging.basicConfig(
     level=logging.INFO,
 )


### PR DESCRIPTION
The release of Spot SDK 5.0.0 allows users to send the hand camera calibration to spot and get back data that reflects that