### PR TITLE
[WUD-2348] Use SDK clock throughout Spot wrapper

### DIFF
--- a/spot_wrapper/spot_arm.py
+++ b/spot_wrapper/spot_arm.py
@@ -22,7 +22,7 @@ from bosdyn.client.robot_command import (
 )
 from bosdyn.client.robot_state import RobotStateClient
 from bosdyn.client.time_sync import TimeSyncEndpoint
-from bosdyn.util import seconds_to_duration
+from bosdyn.util import now_sec, seconds_to_duration
 
 from spot_wrapper.spot_leash import SpotLeashContextProtocol
 from spot_wrapper.wrapper_helpers import RobotState
@@ -99,7 +99,7 @@ class SpotArm:
             return False, str(e), None
 
     def manipulation_command(self, request: manipulation_api_pb2):
-        end_time = time.time() + self._max_command_duration
+        end_time = now_sec() + self._max_command_duration
         return self._manipulation_request(
             request,
             end_time_secs=end_time,
@@ -539,15 +539,13 @@ class SpotArm:
                 self._logger.info(msg)
                 return False, msg
             else:
-                end_time = self._robot.time_sync.robot_timestamp_from_local_secs(time.time() + cmd_duration)
+                end_time = self._robot.time_sync.robot_timestamp_from_local_secs(now_sec() + cmd_duration)
                 arm_velocity_command.end_time.CopyFrom(end_time)
 
                 robot_command = robot_command_pb2.RobotCommand()
                 robot_command.synchronized_command.arm_command.arm_velocity_command.CopyFrom(arm_velocity_command)
 
-                self._robot_command_client.robot_command(
-                    command=robot_command, end_time_secs=time.time() + cmd_duration
-                )
+                self._robot_command_client.robot_command(command=robot_command, end_time_secs=now_sec() + cmd_duration)
 
         except Exception as e:
             return (
@@ -574,9 +572,9 @@ class SpotArm:
             True if successfully completed the gripper command, False if it failed
         """
         if timeout_sec is not None:
-            start_time = time.time()
+            start_time = now_sec()
             end_time = start_time + timeout_sec
-            now = time.time()
+            now = now_sec()
 
         while timeout_sec is None or now < end_time:
             feedback_resp = robot_command_client.robot_command_feedback(cmd_id)
@@ -594,7 +592,7 @@ class SpotArm:
                 return False
 
             time.sleep(0.1)
-            now = time.time()
+            now = now_sec()
         return False
 
     @staticmethod
@@ -616,9 +614,9 @@ class SpotArm:
             True if successfully completed the manipulation, False if the manipulation failed
         """
         if timeout_sec is not None:
-            start_time = time.time()
+            start_time = now_sec()
             end_time = start_time + timeout_sec
-            now = time.time()
+            now = now_sec()
 
         while timeout_sec is None or now < end_time:
             feedback_request = manipulation_api_pb2.ManipulationApiFeedbackRequest(manipulation_cmd_id=cmd_id)
@@ -635,7 +633,7 @@ class SpotArm:
                 return False
 
             time.sleep(0.1)
-            now = time.time()
+            now = now_sec()
         return False
 
     def grasp_3d(self, frame: str, object_rt_frame: typing.List[float]) -> typing.Tuple[bool, str]:

--- a/spot_wrapper/spot_check.py
+++ b/spot_wrapper/spot_check.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import typing
 
 from bosdyn.api import header_pb2
@@ -7,6 +6,7 @@ from bosdyn.client import robot_command
 from bosdyn.client.lease import Lease
 from bosdyn.client.robot import Robot
 from bosdyn.client.spot_check import SpotCheckClient, run_spot_check, spot_check_pb2
+from bosdyn.util import now_nsec, now_sec
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from spot_wrapper.wrapper_helpers import RobotState
@@ -81,7 +81,7 @@ class SpotCheck:
         Returns:
             Feedback from the spot check command
         """
-        start_time_seconds, start_time_ns = int(time.time()), int(time.time_ns() % 1e9)
+        start_time_seconds, start_time_ns = int(now_sec()), int(now_nsec() % 1e9)
         req = spot_check_pb2.SpotCheckFeedbackRequest(
             header=header_pb2.RequestHeader(
                 request_timestamp=Timestamp(seconds=start_time_seconds, nanos=start_time_ns),
@@ -97,7 +97,7 @@ class SpotCheck:
 
     def _spot_check_cmd(self, command: spot_check_pb2.SpotCheckCommandRequest):
         """Send a Spot Check command"""
-        start_time_seconds, start_time_ns = int(time.time()), int(time.time_ns() % 1e9)
+        start_time_seconds, start_time_ns = int(now_sec()), int(now_nsec() % 1e9)
         req = spot_check_pb2.SpotCheckCommandRequest(
             header=header_pb2.RequestHeader(
                 request_timestamp=Timestamp(seconds=start_time_seconds, nanos=start_time_ns),

--- a/spot_wrapper/spot_dance.py
+++ b/spot_wrapper/spot_dance.py
@@ -25,6 +25,7 @@ from bosdyn.client import ResponseError
 from bosdyn.client.common import FutureWrapper
 from bosdyn.client.exceptions import UnauthenticatedError
 from bosdyn.client.robot import Robot
+from bosdyn.util import now_sec
 from google.protobuf import text_format
 
 
@@ -190,7 +191,7 @@ class SpotDance:
         Execute choreography that has already been uploaded to the robot.
         Returns a future wrapper when use_async is true, success, msg tuple otherwise
         """
-        client_start_time = time.time()
+        client_start_time = now_sec()
 
         try:
             if use_async:
@@ -259,6 +260,7 @@ class SpotDance:
             # Setup common response in case of exception
             result_msg = f"Choreography uploaded with message: {message} \n"
             self._robot.power_on()
+
             (result, message) = self.execute_choreography_by_name(
                 choreography.name, start_slice=start_slice, use_async=False
             )

--- a/spot_wrapper/wrapper.py
+++ b/spot_wrapper/wrapper.py
@@ -60,6 +60,7 @@ from bosdyn.client.time_sync import TimeSyncEndpoint
 from bosdyn.client.world_object import WorldObjectClient
 from bosdyn.geometry import EulerZXY
 from bosdyn.mission.client import MissionClient
+from bosdyn.util import now_sec
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from .spot_arm import SpotArm
@@ -235,7 +236,7 @@ class AsyncIdle(AsyncPeriodicQuery):
         is_moving = False
 
         if self._spot_wrapper.last_velocity_command_time is not None:
-            if time.time() < self._spot_wrapper.last_velocity_command_time:
+            if now_sec() < self._spot_wrapper.last_velocity_command_time:
                 is_moving = True
             else:
                 self._spot_wrapper.last_velocity_command_time = None
@@ -1309,7 +1310,7 @@ class SpotWrapper:
         Returns:
             Tuple of bool success and a string message
         """
-        end_time = time.time() + cmd_duration
+        end_time = now_sec() + cmd_duration
         if body_height:
             current_mobility_params = self.get_mobility_params()
             height_adjusted_params = RobotCommandBuilder.mobility_params(
@@ -1395,7 +1396,7 @@ class SpotWrapper:
         self.is_stopping = False
         self.last_trajectory_command_precise = precise_position
         self._logger.info("got command duration of {}".format(cmd_duration))
-        end_time = time.time() + cmd_duration
+        end_time = now_sec() + cmd_duration
         if frame_name == "vision":
             vision_tform_body = frame_helpers.get_vision_tform_body(
                 self._robot_state_client.get_robot_state().kinematic_state.transforms_snapshot
@@ -1441,7 +1442,7 @@ class SpotWrapper:
     def robot_command(
         self, robot_command: robot_command_pb2.RobotCommand, duration: float = MAX_COMMAND_DURATION
     ) -> typing.Tuple[bool, str, typing.Optional[int]]:
-        end_time = time.time() + duration
+        end_time = now_sec() + duration
         return self._robot_command(
             robot_command,
             end_time_secs=end_time,
@@ -1449,7 +1450,7 @@ class SpotWrapper:
         )
 
     def manipulation_command(self, request):
-        end_time = time.time() + MAX_COMMAND_DURATION
+        end_time = now_sec() + MAX_COMMAND_DURATION
         return self._manipulation_request(
             request,
             end_time_secs=end_time,


### PR DESCRIPTION
This is a best effort atempt at using the SDK clock source as much as possible in `spot_wrapper`. Not everything will, as the SDK provides no sleep primitives nor is it consistent about using it. 

Still, this gets us a bit closer to normalizing its use.