### PR TITLE
Change to new RAI Institute copyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute.  All rights reserved.
 
 name: CI
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute, Inc.  All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute.  All rights reserved.
 
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 MASKOR & Boston Dynamics AI Institute
+Copyright (c) 2022 MASKOR & Robotics and AI Institute LLC dba RAI Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spot_wrapper/calibration/automatic_camera_calibration_robot.py
+++ b/spot_wrapper/calibration/automatic_camera_calibration_robot.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
 
 # What's below can be used in standalone tool

--- a/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
+++ b/spot_wrapper/calibration/calibrate_multistereo_cameras_with_charuco_cli.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
 
 import argparse

--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
 
 import argparse

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
 
 import argparse

--- a/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
+++ b/spot_wrapper/calibration/spot_in_hand_camera_calibration.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copy reference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
 
 import logging

--- a/spot_wrapper/testing/__init__.py
+++ b/spot_wrapper/testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 """
 This subpackage provides `pytest` compatible machinery to test Spot SDK use.

--- a/spot_wrapper/testing/credentials/__init__.py
+++ b/spot_wrapper/testing/credentials/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import dataclasses
 import pathlib

--- a/spot_wrapper/testing/fixtures.py
+++ b/spot_wrapper/testing/fixtures.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import concurrent.futures
 import dataclasses

--- a/spot_wrapper/testing/grpc.py
+++ b/spot_wrapper/testing/grpc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import collections.abc
 import concurrent.futures

--- a/spot_wrapper/testing/helpers.py
+++ b/spot_wrapper/testing/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import functools
 import typing

--- a/spot_wrapper/testing/mocks/__init__.py
+++ b/spot_wrapper/testing/mocks/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 from spot_wrapper.testing.grpc import AutoServicer
 from spot_wrapper.testing.mocks.auth import MockAuthService

--- a/spot_wrapper/testing/mocks/auth.py
+++ b/spot_wrapper/testing/mocks/auth.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import grpc
 from bosdyn.api.auth_pb2 import GetAuthTokenRequest, GetAuthTokenResponse

--- a/spot_wrapper/testing/mocks/cam.py
+++ b/spot_wrapper/testing/mocks/cam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import typing
 

--- a/spot_wrapper/testing/mocks/directory.py
+++ b/spot_wrapper/testing/mocks/directory.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import typing
 

--- a/spot_wrapper/testing/mocks/estop.py
+++ b/spot_wrapper/testing/mocks/estop.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import itertools
 import typing

--- a/spot_wrapper/testing/mocks/keepalive.py
+++ b/spot_wrapper/testing/mocks/keepalive.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import itertools
 import typing

--- a/spot_wrapper/testing/mocks/lease.py
+++ b/spot_wrapper/testing/mocks/lease.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import typing
 

--- a/spot_wrapper/testing/mocks/license.py
+++ b/spot_wrapper/testing/mocks/license.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import grpc
 from bosdyn.api.license_pb2 import (

--- a/spot_wrapper/testing/mocks/payload.py
+++ b/spot_wrapper/testing/mocks/payload.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import typing
 

--- a/spot_wrapper/testing/mocks/power.py
+++ b/spot_wrapper/testing/mocks/power.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 from typing import Any
 

--- a/spot_wrapper/testing/mocks/robot_id.py
+++ b/spot_wrapper/testing/mocks/robot_id.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import grpc
 from bosdyn.api.robot_id_pb2 import RobotIdRequest, RobotIdResponse

--- a/spot_wrapper/testing/mocks/robot_state.py
+++ b/spot_wrapper/testing/mocks/robot_state.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import typing
 

--- a/spot_wrapper/testing/mocks/time_sync.py
+++ b/spot_wrapper/testing/mocks/time_sync.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import grpc
 from bosdyn.api.time_sync_pb2 import (

--- a/spot_wrapper/testing/services.py
+++ b/spot_wrapper/testing/services.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 from bosdyn.api.arm_surface_contact_service_pb2_grpc import (
     ArmSurfaceContactServiceServicer,

--- a/spot_wrapper/tests/test_auto_servicer.py
+++ b/spot_wrapper/tests/test_auto_servicer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import concurrent.futures
 import math

--- a/spot_wrapper/tests/test_proxy_servicer.py
+++ b/spot_wrapper/tests/test_proxy_servicer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import concurrent.futures
 from typing import Iterator

--- a/spot_wrapper/tests/test_wrapper.py
+++ b/spot_wrapper/tests/test_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. See LICENSE file for more info.
 
 import logging
 import time


### PR DESCRIPTION
Automated update to fix copyright headers with new organization name.

"Boston Dynamics AI Institute LLC" has been changed to "Robotics and AI Institute LLC" or "RAI Institute" for short.

Note that the date-stamps in the copyright headers have been preserved.

This PR was created automatically.