### PR TITLE
[PER-170] augmenting calibration positions 

### DIFF
--- a/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
+++ b/spot_wrapper/calibration/calibrate_spot_hand_camera_cli.py
@@ -71,7 +71,8 @@ def spot_main() -> None:
         images, poses = get_multiple_perspective_camera_calibration_dataset(
             auto_cam_cal_robot=in_hand_bot,
             max_num_images=args.max_num_images,
-            distances=np.arange(*args.dist_from_board_viewpoint_range),
+            distances_z=np.arange(*args.dist_from_board_viewpoint_range),
+            distances_x=np.arange(*args.dist_along_board_width),
             x_axis_rots=np.arange(*args.x_axis_rot_viewpoint_range),
             y_axis_rots=np.arange(*args.y_axis_rot_viewpoint_range),
             z_axis_rots=np.arange(*args.z_axis_rot_viewpoint_range),
@@ -125,6 +126,19 @@ def calibrate_robot_cli(parser: argparse.ArgumentParser = None) -> argparse.Argu
         default=[0.5, 0.6, 0.1],
         help=(
             "What distances to conduct calibrations at relative to the board. (along the normal vector) "
+            "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "
+            "These are used to sample viewpoints for automatic collection. "
+        ),
+    )
+    parser.add_argument(
+        "--dist_along_board_width",
+        "-dabw",
+        nargs="+",
+        type=float,
+        dest="dist_along_board_width",
+        default=[-0.3, 0.4, 0.2],
+        help=(
+            "What distances to conduct calibrations at relative to the board. (along the board width) "
             "Three value array arg defines the [Start, Stop), step. for the viewpoint sweep. "
             "These are used to sample viewpoints for automatic collection. "
         ),

--- a/spot_wrapper/calibration/calibration_util.py
+++ b/spot_wrapper/calibration/calibration_util.py
@@ -102,7 +102,8 @@ SPOT_DEFAULT_CHARUCO = create_charuco_board(
 def get_multiple_perspective_camera_calibration_dataset(
     auto_cam_cal_robot: AutomaticCameraCalibrationRobot,
     max_num_images: int = 10000,
-    distances: Optional[np.ndarray] = None,
+    distances_x: Optional[np.ndarray] = None,
+    distances_z: Optional[np.ndarray] = None,
     x_axis_rots: Optional[np.ndarray] = None,
     y_axis_rots: Optional[np.ndarray] = None,
     z_axis_rots: Optional[np.ndarray] = None,
@@ -159,7 +160,8 @@ def get_multiple_perspective_camera_calibration_dataset(
     viewpoints = get_relative_viewpoints_from_board_pose_and_param(
         R_vision_to_target,
         tvec_vision_to_target,
-        distances=distances,
+        distances_x=distances_x,
+        distances_z=distances_z,
         x_axis_rots=x_axis_rots,
         y_axis_rots=y_axis_rots,
         z_axis_rots=z_axis_rots,
@@ -881,7 +883,8 @@ def convert_camera_t_viewpoint_to_origin_t_planning_frame(
 def get_relative_viewpoints_from_board_pose_and_param(
     R_board: np.ndarray,
     tvec: np.ndarray,
-    distances: Optional[np.ndarray] = None,
+    distances_x: Optional[np.ndarray] = None,
+    distances_z: Optional[np.ndarray] = None,
     x_axis_rots: Optional[np.ndarray] = None,
     y_axis_rots: Optional[np.ndarray] = None,
     z_axis_rots: Optional[np.ndarray] = None,
@@ -934,8 +937,10 @@ def get_relative_viewpoints_from_board_pose_and_param(
         List[np.ndarray]: a list of 4x4 homogenous transforms to visit in the "principal" cameras
             frame
     """
-    if distances is None:
-        distances = np.arange(0.5, 0.7, 0.1)
+    if distances_x is None:
+        distances_x = np.arange(0.3, 0.7, 0.1)
+    if distances_z is None:
+        distances_z = np.arange(-0.2, 0.3, 0.1)
     if x_axis_rots is None:
         x_axis_rots = np.arange(-20, 21, 5)
     if y_axis_rots is None:
@@ -949,7 +954,8 @@ def get_relative_viewpoints_from_board_pose_and_param(
         x_axis_rots = [radians(deg) for deg in x_axis_rots]
         y_axis_rots = [radians(deg) for deg in y_axis_rots]
         z_axis_rots = [radians(deg) for deg in z_axis_rots]
-    translations = [tvec + R_board[:, 2] * dist for dist in distances]
+
+    translations = [(tvec + R_board[:, 2] * dist + R_board[:, 0] * d2) for dist in distances_z for d2 in distances_x]
     R_base = R_board @ R_align_board_frame_with_camera
 
     def euler_to_rotation_matrix(roll: float, pitch: float, yaw: float) -> np.ndarray:


### PR DESCRIPTION
we augment the calibration to allow view diversity along the width of the board, i.e., the x axis.
in other words, we can now vary the position of the views taken during collection.

this makes the calibration views configurable. the above change also moves the camera along the width
of the board, not just distance to the board. 

Testing: I tested this using my calibration_gui.py. 
Here are the configuration parameters is used for this collect:
for the --dist_from_board_viewpoint_range
i used: [0.2, 0.6, 0.15]
and for --dist_along_board_width
i used: [-0.3, 0.4, 0.2]

which, if you collection is taken with spot about 1.5 meters away from the board, i get over 300 views.
to understnad the error of calibration, i took 4 collects, and here are the estimates of the translation between the RGB and depth frames:

<img width="641" height="191" alt="image" src="https://github.com/user-attachments/assets/65019c3c-b646-48bf-890f-480fcee19dcf" />


Here, you can see something typical for calibration, the error on the x,y values are about a millimeter, but the error for the z values are about a centimeter. 

Please note that when with the current set of views (on main), the error is far greater. i am getting about 10 centimeters in the z direction